### PR TITLE
Add median line

### DIFF
--- a/src/main/java/org/mastodon/mamut/clustering/ui/DendrogramPanel.java
+++ b/src/main/java/org/mastodon/mamut/clustering/ui/DendrogramPanel.java
@@ -171,6 +171,8 @@ public class DendrogramPanel< T > extends JPanel
 			final Graphics2D g2, final Stroke stroke, final double xModelValue, final DisplayMetrics displayMetrics
 	)
 	{
+		if ( Double.isNaN( xModelValue ) )
+			return;
 		Stroke defaultStroke = g2.getStroke();
 		try
 		{

--- a/src/main/java/org/mastodon/mamut/clustering/ui/DendrogramPanel.java
+++ b/src/main/java/org/mastodon/mamut/clustering/ui/DendrogramPanel.java
@@ -78,7 +78,7 @@ public class DendrogramPanel< T > extends JPanel
 
 	private static final boolean SHOW_SCALE = true;
 
-	private static final int BORDER_TOP = 20;
+	private static final int BORDER_TOP = 50;
 
 	private static final int BORDER_LEFT = 20;
 
@@ -181,8 +181,8 @@ public class DendrogramPanel< T > extends JPanel
 
 	Line2D getVerticalLine( final double xModelValue, final DisplayMetrics displayMetrics )
 	{
-		int yDendrogramOrigin = BORDER_BOTTOM + BORDER_TOP;
-		int yDendrogramEnd = getHeight() - BORDER_BOTTOM;
+		int yDendrogramOrigin = BORDER_TOP + BORDER_BOTTOM;
+		int yDendrogramEnd = getHeight() - BORDER_TOP;
 		int lineX = getDisplayXCoordinate( xModelValue, displayMetrics );
 		return new Line2D.Float( lineX, yDendrogramOrigin, lineX, yDendrogramEnd );
 	}
@@ -248,10 +248,10 @@ public class DendrogramPanel< T > extends JPanel
 			}
 
 			widthDisplay = componentWidth - BORDER_LEFT - BORDER_RIGHT - nameOffset;
-			heightDisplay = componentHeight - BORDER_TOP - BORDER_BOTTOM - axisHeight;
+			heightDisplay = componentHeight - BORDER_BOTTOM - BORDER_TOP - axisHeight;
 
 			xDisplayOrigin = BORDER_LEFT;
-			yDisplayOrigin = BORDER_BOTTOM + axisHeight;
+			yDisplayOrigin = BORDER_TOP + axisHeight;
 
 			xConversionFactor = widthDisplay / modelMetrics.wModel;
 			yConversionFactor = heightDisplay / modelMetrics.hModel;

--- a/src/main/java/org/mastodon/mamut/clustering/ui/DendrogramPanel.java
+++ b/src/main/java/org/mastodon/mamut/clustering/ui/DendrogramPanel.java
@@ -208,9 +208,6 @@ public class DendrogramPanel< T > extends JPanel
 
 	private CustomizedClusterComponent createComponent( final Cluster cluster )
 	{
-		if ( cluster == null )
-			return null;
-
 		return new CustomizedClusterComponent( cluster, classification.getObjectClassifications() );
 	}
 
@@ -351,8 +348,6 @@ public class DendrogramPanel< T > extends JPanel
 			if ( classification == null )
 				return;
 			Cluster cluster = classification.getRootCluster();
-			if ( cluster == null )
-				return;
 			if ( cluster.getDistanceValue() > 1d )
 				return;
 			int zeros = countZerosAfterDecimalPoint( cluster.getDistanceValue() );

--- a/src/main/java/org/mastodon/mamut/clustering/ui/DendrogramPanel.java
+++ b/src/main/java/org/mastodon/mamut/clustering/ui/DendrogramPanel.java
@@ -73,6 +73,9 @@ public class DendrogramPanel< T > extends JPanel
 	private static final BasicStroke CUT_OFF_LINE_STROKE =
 			new BasicStroke( 1.75f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL, 0, new float[] { 5, 5 }, 0 );
 
+	private static final BasicStroke MEDIAN_LINE_STROKE =
+			new BasicStroke( 1.75f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL, 0, new float[] { 10, 10 }, 0 );
+
 	static final Color CLUSTER_LINE_COLOR = Color.BLACK;
 
 	private static final boolean SHOW_DISTANCE_VALUES = false;
@@ -141,6 +144,7 @@ public class DendrogramPanel< T > extends JPanel
 				axis.paint( g2 );
 			}
 			paintCutoffLine( g2, metrics );
+			paintMedianLine( g2, metrics );
 		}
 		else
 		{
@@ -155,6 +159,12 @@ public class DendrogramPanel< T > extends JPanel
 	{
 		paintVerticalLine( g2, CUT_OFF_LINE_STROKE, classification.getCutoff(), displayMetrics );
 		paintLineLegend( g2, "Classification threshold", 1, CUT_OFF_LINE_STROKE );
+	}
+
+	private void paintMedianLine( final Graphics2D g2, final DisplayMetrics displayMetrics )
+	{
+		paintVerticalLine( g2, MEDIAN_LINE_STROKE, classification.getMedian(), displayMetrics );
+		paintLineLegend( g2, "Median of tree similarities", 2, MEDIAN_LINE_STROKE );
 	}
 
 	private void paintVerticalLine(

--- a/src/main/java/org/mastodon/mamut/clustering/ui/DendrogramPanel.java
+++ b/src/main/java/org/mastodon/mamut/clustering/ui/DendrogramPanel.java
@@ -36,6 +36,7 @@ import org.mastodon.mamut.clustering.util.Classification;
 import javax.swing.JPanel;
 import java.awt.BasicStroke;
 import java.awt.Color;
+import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
@@ -365,6 +366,7 @@ public class DendrogramPanel< T > extends JPanel
 		private void paint( final Graphics2D g2 )
 		{
 			g2.draw( line );
+			drawLegend( g2 );
 			for ( Pair< Line2D, String > tick : ticks )
 			{
 				Line2D tickLine = tick.getLeft();
@@ -376,6 +378,17 @@ public class DendrogramPanel< T > extends JPanel
 						( int ) tickLine.getY2() - SCALE_TICK_LABEL_PADDING
 				);
 			}
+		}
+
+		private void drawLegend( final Graphics2D g2 )
+		{
+			FontMetrics fontMetrics = g2.getFontMetrics();
+			int y = displayMetrics.yDisplayOrigin - SCALE_PADDING - SCALE_TICK_LABEL_PADDING - SCALE_TICK_LENGTH
+					- fontMetrics.getHeight();
+			g2.drawString( "dissimilar lineages", ( int ) line.getX1(), y );
+			String similarText = "similar lineages";
+			fontMetrics.getStringBounds( similarText, g2 );
+			g2.drawString( similarText, ( int ) line.getX2() - ( int ) fontMetrics.getStringBounds( similarText, g2 ).getWidth(), y );
 		}
 	}
 }

--- a/src/main/java/org/mastodon/mamut/clustering/ui/DendrogramPanel.java
+++ b/src/main/java/org/mastodon/mamut/clustering/ui/DendrogramPanel.java
@@ -154,6 +154,7 @@ public class DendrogramPanel< T > extends JPanel
 	private void paintCutoffLine( final Graphics2D g2, final DisplayMetrics displayMetrics )
 	{
 		paintVerticalLine( g2, CUT_OFF_LINE_STROKE, classification.getCutoff(), displayMetrics );
+		paintLineLegend( g2, "Classification threshold", 1, CUT_OFF_LINE_STROKE );
 	}
 
 	private void paintVerticalLine(
@@ -165,6 +166,27 @@ public class DendrogramPanel< T > extends JPanel
 		{
 			g2.setStroke( stroke );
 			g2.draw( getVerticalLine( xModelValue, displayMetrics ) );
+		}
+		finally
+		{
+			g2.setStroke( defaultStroke );
+		}
+	}
+
+	private void paintLineLegend( final Graphics2D g2, final String text, final int position, final Stroke stroke )
+	{
+		Stroke defaultStroke = g2.getStroke();
+		try
+		{
+			g2.setStroke( stroke );
+			int fontHeight = g2.getFontMetrics().getHeight();
+			int fontSpacing = g2.getFontMetrics().getHeight() - g2.getFontMetrics().getAscent();
+			int yText = fontHeight * position;
+			float yLine = yText - fontHeight / 2f + fontSpacing;
+			int width = 50;
+			int offset = 5;
+			g2.draw( new Line2D.Float( BORDER_LEFT, yLine, BORDER_LEFT + ( float ) width, yLine ) );
+			g2.drawString( text, BORDER_LEFT + width + offset, yText );
 		}
 		finally
 		{

--- a/src/main/java/org/mastodon/mamut/clustering/util/Classification.java
+++ b/src/main/java/org/mastodon/mamut/clustering/util/Classification.java
@@ -92,7 +92,7 @@ public class Classification< T >
 		this.cutoff = cutoff;
 
 		double[] upperTriangle = ClusterUtils.getUpperTriangle( distances );
-		this.median = upperTriangle.length == 0 ? 0 : Util.median( upperTriangle );
+		this.median = upperTriangle.length == 0 ? Double.NaN : Util.median( upperTriangle );
 	}
 
 	public Set< ObjectClassification< T > > getObjectClassifications()

--- a/src/main/java/org/mastodon/mamut/clustering/util/Classification.java
+++ b/src/main/java/org/mastodon/mamut/clustering/util/Classification.java
@@ -76,7 +76,7 @@ public class Classification< T >
 	 * 						</ul>
 	 * @param rootCluster the root {@link Cluster} object, from which the results of the algorithm can be accessed
 	 * @param cutoff the cutoff value of classification, i.e. where the dendrogram is cut
-	 * @param distances the distance matrix of the objects that were clustered
+	 * @param distances the distance matrix of the objects that were clustered. It is assumed to be symmetric and the diagonal values are assumed to be 0.
 	 */
 	public Classification( final List< Pair< Set< T >, Cluster > > classifiedObjects, @Nullable final Cluster rootCluster, double cutoff,
 			double[][] distances )
@@ -93,8 +93,8 @@ public class Classification< T >
 		this.rootCluster = rootCluster;
 		this.cutoff = cutoff;
 
-		double[] allDistances = Stream.of( distances ).flatMapToDouble( DoubleStream::of ).toArray();
-		this.median = Util.median( allDistances );
+		double[] nonZeroValues = Stream.of( distances ).flatMapToDouble( DoubleStream::of ).filter( value -> value != 0 ).toArray();
+		this.median = Util.median( nonZeroValues );
 	}
 
 	public Set< ObjectClassification< T > > getObjectClassifications()

--- a/src/main/java/org/mastodon/mamut/clustering/util/Classification.java
+++ b/src/main/java/org/mastodon/mamut/clustering/util/Classification.java
@@ -37,8 +37,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.DoubleStream;
-import java.util.stream.Stream;
 
 /**
  * A class that encapsulates the result of a clustering algorithm.<br>
@@ -93,8 +91,8 @@ public class Classification< T >
 		this.rootCluster = rootCluster;
 		this.cutoff = cutoff;
 
-		double[] nonZeroValues = Stream.of( distances ).flatMapToDouble( DoubleStream::of ).filter( value -> value != 0 ).toArray();
-		this.median = nonZeroValues.length == 0 ? 0 : Util.median( nonZeroValues );
+		double[] upperTriangle = ClusterUtils.getUpperTriangle( distances );
+		this.median = upperTriangle.length == 0 ? 0 : Util.median( upperTriangle );
 	}
 
 	public Set< ObjectClassification< T > > getObjectClassifications()

--- a/src/main/java/org/mastodon/mamut/clustering/util/Classification.java
+++ b/src/main/java/org/mastodon/mamut/clustering/util/Classification.java
@@ -32,7 +32,6 @@ import com.apporiented.algorithm.clustering.Cluster;
 import net.imglib2.util.Util;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.annotation.Nullable;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -58,7 +57,6 @@ public class Classification< T >
 {
 	private final Set< ObjectClassification< T > > objectClassifications;
 
-	@Nullable
 	private final Cluster rootCluster;
 
 	private final double cutoff;
@@ -76,8 +74,7 @@ public class Classification< T >
 	 * @param cutoff the cutoff value of classification, i.e. where the dendrogram is cut
 	 * @param distances the distance matrix of the objects that were clustered. It is assumed to be symmetric and the diagonal values are assumed to be 0.
 	 */
-	public Classification( final List< Pair< Set< T >, Cluster > > classifiedObjects, @Nullable final Cluster rootCluster, double cutoff,
-			double[][] distances )
+	public Classification( final List< Pair< Set< T >, Cluster > > classifiedObjects, final Cluster rootCluster, double cutoff )
 
 	{
 		this.objectClassifications = new HashSet<>();
@@ -100,7 +97,6 @@ public class Classification< T >
 		return objectClassifications;
 	}
 
-	@Nullable
 	public Cluster getRootCluster()
 	{
 		return rootCluster;

--- a/src/main/java/org/mastodon/mamut/clustering/util/Classification.java
+++ b/src/main/java/org/mastodon/mamut/clustering/util/Classification.java
@@ -108,11 +108,22 @@ public class Classification< T >
 		return rootCluster;
 	}
 
+	/**
+	 * Returns the cutoff value of classification, i.e. where the value, where the dendrogram is cut.
+	 *
+	 * @return the cutoff value of classification
+	 */
 	public double getCutoff()
 	{
 		return cutoff;
 	}
 
+	/**
+	 * Returns the median of the non-zero values of the distance matrix that this classification represents.<p>
+	 * Since, the distance matrix is assumed to be symmetric and the diagonal values are assumed to be 0, the median value is equivalent to the median value of the upper triangle values of the distance matrix.
+	 *
+	 * @return the median of the non-zero values of the distance matrix
+	 */
 	public double getMedian()
 	{
 		return median;

--- a/src/main/java/org/mastodon/mamut/clustering/util/Classification.java
+++ b/src/main/java/org/mastodon/mamut/clustering/util/Classification.java
@@ -117,10 +117,9 @@ public class Classification< T >
 	}
 
 	/**
-	 * Returns the median of the non-zero values of the distance matrix that this classification represents.<p>
-	 * Since, the distance matrix is assumed to be symmetric and the diagonal values are assumed to be 0, the median value is equivalent to the median value of the upper triangle values of the distance matrix.
+	 * Returns the median of the upper triangle values of the distance matrix that this classification represents.<p>
 	 *
-	 * @return the median of the non-zero values of the distance matrix
+	 * @return the median of the upper triangle values of the distance matrix
 	 */
 	public double getMedian()
 	{

--- a/src/main/java/org/mastodon/mamut/clustering/util/Classification.java
+++ b/src/main/java/org/mastodon/mamut/clustering/util/Classification.java
@@ -29,6 +29,7 @@
 package org.mastodon.mamut.clustering.util;
 
 import com.apporiented.algorithm.clustering.Cluster;
+import net.imglib2.util.Util;
 import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nullable;
@@ -36,6 +37,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.DoubleStream;
+import java.util.stream.Stream;
 
 /**
  * A class that encapsulates the result of a clustering algorithm.<br>
@@ -62,6 +65,8 @@ public class Classification< T >
 
 	private final double cutoff;
 
+	private final double median;
+
 	/**
 	 * Creates a new {@link Classification} object.
 	 * @param classifiedObjects a {@link List} of {@link Pair} objects, where each pair contains:
@@ -71,8 +76,11 @@ public class Classification< T >
 	 * 						</ul>
 	 * @param rootCluster the root {@link Cluster} object, from which the results of the algorithm can be accessed
 	 * @param cutoff the cutoff value of classification, i.e. where the dendrogram is cut
+	 * @param distances the distance matrix of the objects that were clustered
 	 */
-	public Classification( final List< Pair< Set< T >, Cluster > > classifiedObjects, @Nullable final Cluster rootCluster, double cutoff )
+	public Classification( final List< Pair< Set< T >, Cluster > > classifiedObjects, @Nullable final Cluster rootCluster, double cutoff,
+			double[][] distances )
+
 	{
 		this.objectClassifications = new HashSet<>();
 		List< Integer > glasbeyColors = ClusterUtils.getGlasbeyColors( classifiedObjects.size() );
@@ -84,6 +92,9 @@ public class Classification< T >
 		}
 		this.rootCluster = rootCluster;
 		this.cutoff = cutoff;
+
+		double[] allDistances = Stream.of( distances ).flatMapToDouble( DoubleStream::of ).toArray();
+		this.median = Util.median( allDistances );
 	}
 
 	public Set< ObjectClassification< T > > getObjectClassifications()
@@ -100,6 +111,11 @@ public class Classification< T >
 	public double getCutoff()
 	{
 		return cutoff;
+	}
+
+	public double getMedian()
+	{
+		return median;
 	}
 
 	Set< Set< T > > getClassifiedObjects()

--- a/src/main/java/org/mastodon/mamut/clustering/util/Classification.java
+++ b/src/main/java/org/mastodon/mamut/clustering/util/Classification.java
@@ -94,7 +94,7 @@ public class Classification< T >
 		this.cutoff = cutoff;
 
 		double[] nonZeroValues = Stream.of( distances ).flatMapToDouble( DoubleStream::of ).filter( value -> value != 0 ).toArray();
-		this.median = Util.median( nonZeroValues );
+		this.median = nonZeroValues.length == 0 ? 0 : Util.median( nonZeroValues );
 	}
 
 	public Set< ObjectClassification< T > > getObjectClassifications()

--- a/src/main/java/org/mastodon/mamut/clustering/util/Classification.java
+++ b/src/main/java/org/mastodon/mamut/clustering/util/Classification.java
@@ -29,7 +29,6 @@
 package org.mastodon.mamut.clustering.util;
 
 import com.apporiented.algorithm.clustering.Cluster;
-import net.imglib2.util.Util;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.HashSet;
@@ -50,6 +49,7 @@ import java.util.stream.Collectors;
  *           </ul>
  *         </li>
  *         <li>the cutoff value of classification, i.e. where the dendrogram is cut</li>
+ *         <li>the median of the upper triangle values of the distance matrix that this classification represents</li>
  *     </ul>
  * @author Stefan Hahmann
  */
@@ -72,9 +72,10 @@ public class Classification< T >
 	 * 						</ul>
 	 * @param rootCluster the root {@link Cluster} object, from which the results of the algorithm can be accessed
 	 * @param cutoff the cutoff value of classification, i.e. where the dendrogram is cut
-	 * @param distances the distance matrix of the objects that were clustered. It is assumed to be symmetric and the diagonal values are assumed to be 0.
+	 * @param median the median of the upper triangle values of the distance matrix that this classification represents
 	 */
-	public Classification( final List< Pair< Set< T >, Cluster > > classifiedObjects, final Cluster rootCluster, double cutoff )
+	public Classification( final List< Pair< Set< T >, Cluster > > classifiedObjects, final Cluster rootCluster, final double cutoff,
+			final double median )
 
 	{
 		this.objectClassifications = new HashSet<>();
@@ -87,9 +88,7 @@ public class Classification< T >
 		}
 		this.rootCluster = rootCluster;
 		this.cutoff = cutoff;
-
-		double[] upperTriangle = ClusterUtils.getUpperTriangle( distances );
-		this.median = upperTriangle.length == 0 ? Double.NaN : Util.median( upperTriangle );
+		this.median = median;
 	}
 
 	public Set< ObjectClassification< T > > getObjectClassifications()

--- a/src/main/java/org/mastodon/mamut/clustering/util/ClusterUtils.java
+++ b/src/main/java/org/mastodon/mamut/clustering/util/ClusterUtils.java
@@ -158,7 +158,7 @@ public class ClusterUtils
 		List< Pair< Set< T >, Cluster > > classesAndClusters = convertClustersToClasses( resultClusters, objectMapping );
 		resetClusterNames( algorithmResult, objectMapping );
 		log( classesAndClusters );
-		return new Classification<>( classesAndClusters, algorithmResult, threshold );
+		return new Classification<>( classesAndClusters, algorithmResult, threshold, distances );
 	}
 
 	private static void resetClusterNames( final Cluster cluster, final Map< String, ? > objectMapping )
@@ -210,14 +210,14 @@ public class ClusterUtils
 							+ objects.length + ")." );
 		else if ( classCount == 1 )
 			return new Classification<>(
-					Collections.singletonList( Pair.of( new HashSet<>( Arrays.asList( objects ) ), null ) ), null, 0d );
+					Collections.singletonList( Pair.of( new HashSet<>( Arrays.asList( objects ) ), null ) ), null, 0d, distances );
 
 		List< Pair< Set< T >, Cluster > > classes = new ArrayList<>();
 		if ( classCount == objects.length )
 		{
 			for ( T name : objects )
 				classes.add( Pair.of( Collections.singleton( name ), null ) );
-			return new Classification<>( classes, null, 0d );
+			return new Classification<>( classes, null, 0d, distances );
 		}
 
 		// NB: the cluster algorithm needs unique names instead of objects

--- a/src/main/java/org/mastodon/mamut/clustering/util/ClusterUtils.java
+++ b/src/main/java/org/mastodon/mamut/clustering/util/ClusterUtils.java
@@ -33,6 +33,7 @@ import com.apporiented.algorithm.clustering.ClusteringAlgorithm;
 import com.apporiented.algorithm.clustering.DefaultClusteringAlgorithm;
 import com.apporiented.algorithm.clustering.LinkageStrategy;
 import net.imglib2.parallel.Parallelization;
+import net.imglib2.util.Util;
 import org.apache.commons.lang3.tuple.Pair;
 import org.mastodon.mamut.clustering.config.SimilarityMeasure;
 import org.mastodon.mamut.treesimilarity.ZhangUnorderedTreeEditDistance;
@@ -44,7 +45,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -164,7 +164,9 @@ public class ClusterUtils
 		List< Pair< Set< T >, Cluster > > classesAndClusters = convertClustersToClasses( resultClusters, objectMapping );
 		resetClusterNames( algorithmResult, objectMapping );
 		log( classesAndClusters );
-		return new Classification<>( classesAndClusters, algorithmResult, threshold, distances );
+		double[] upperTriangle = ClusterUtils.getUpperTriangle( distances );
+		double median = upperTriangle.length == 0 ? Double.NaN : Util.median( upperTriangle );
+		return new Classification<>( classesAndClusters, algorithmResult, threshold, median );
 	}
 
 	private static void resetClusterNames( final Cluster cluster, final Map< String, ? > objectMapping )

--- a/src/main/java/org/mastodon/mamut/clustering/util/ClusterUtils.java
+++ b/src/main/java/org/mastodon/mamut/clustering/util/ClusterUtils.java
@@ -154,6 +154,12 @@ public class ClusterUtils
 				break;
 			resultClusters.add( cluster );
 		}
+		if ( resultClusters.isEmpty() )
+		{
+			Cluster pseudoRoot = new Cluster( null );
+			pseudoRoot.addChild( algorithmResult );
+			resultClusters.add( pseudoRoot );
+		}
 
 		List< Pair< Set< T >, Cluster > > classesAndClusters = convertClustersToClasses( resultClusters, objectMapping );
 		resetClusterNames( algorithmResult, objectMapping );
@@ -208,17 +214,6 @@ public class ClusterUtils
 			throw new IllegalArgumentException(
 					"number of classes (" + classCount + ") must be less than or equal to the number of objects to be classified ("
 							+ objects.length + ")." );
-		else if ( classCount == 1 )
-			return new Classification<>(
-					Collections.singletonList( Pair.of( new HashSet<>( Arrays.asList( objects ) ), null ) ), null, 0d, distances );
-
-		List< Pair< Set< T >, Cluster > > classes = new ArrayList<>();
-		if ( classCount == objects.length )
-		{
-			for ( T name : objects )
-				classes.add( Pair.of( Collections.singleton( name ), null ) );
-			return new Classification<>( classes, null, 0d, distances );
-		}
 
 		// NB: the cluster algorithm needs unique names instead of objects
 		Map< String, T > objectMapping = objectMapping( objects );
@@ -255,6 +250,8 @@ public class ClusterUtils
 
 	private static double getThreshold( final List< Cluster > sortedClusters, int classCount )
 	{
+		if ( classCount == 1 )
+			return Double.MAX_VALUE;
 		double threshold = sortedClusters.get( classCount - 2 ).getDistanceValue();
 		if ( sortedClusters.size() < classCount )
 			return threshold;

--- a/src/main/java/org/mastodon/mamut/clustering/util/ClusterUtils.java
+++ b/src/main/java/org/mastodon/mamut/clustering/util/ClusterUtils.java
@@ -341,4 +341,44 @@ public class ClusterUtils
 		Collections.sort( list );
 		return list;
 	}
+
+	/**
+	 * Gets the upper triangle of a two-dimensional quadratic array and outputs it as a one-dimensional array.
+	 * E.g. for the following matrix:
+	 * <pre>
+	 *     0 1 2 3
+	 *     1 0 4 5
+	 *     2 4 0 6
+	 *     3 5 6 0
+	 * </pre>
+	 * the upper triangle is:
+	 * <pre>
+	 *     [1 2 3 4 5 6]
+	 * </pre>
+	 *
+	 * @param twoDimensionalArray a two-dimensional quadratic array
+	 * @return the upper triangle of the given two-dimensional array as a one-dimensional array. If the given array is {@code null}, empty or has length 1, an empty array is returned.
+	 * @throws IllegalArgumentException if the given array is not quadratic
+	 */
+	public static double[] getUpperTriangle( final double[][] twoDimensionalArray )
+	{
+		if ( twoDimensionalArray == null )
+			return new double[ 0 ];
+		int inputLength = twoDimensionalArray.length;
+		if ( inputLength <= 1 )
+			return new double[ 0 ];
+		if ( twoDimensionalArray.length != twoDimensionalArray[ 0 ].length )
+			throw new IllegalArgumentException( "The given array is not quadratic." );
+		int outputLength = ( inputLength * inputLength - inputLength ) / 2;
+		double[] array = new double[ outputLength ];
+		int index = 0;
+		for ( int i = 0; i < inputLength; i++ )
+			for ( int j = i; j < inputLength; j++ )
+			{
+				if ( i == j )
+					continue;
+				array[ index++ ] = twoDimensionalArray[ i ][ j ];
+			}
+		return array;
+	}
 }

--- a/src/main/java/org/mastodon/mamut/clustering/util/ClusterUtils.java
+++ b/src/main/java/org/mastodon/mamut/clustering/util/ClusterUtils.java
@@ -372,12 +372,8 @@ public class ClusterUtils
 		double[] array = new double[ outputLength ];
 		int index = 0;
 		for ( int i = 0; i < inputLength; i++ )
-			for ( int j = i; j < inputLength; j++ )
-			{
-				if ( i == j )
-					continue;
+			for ( int j = i + 1; j < inputLength; j++ )
 				array[ index++ ] = twoDimensionalArray[ i ][ j ];
-			}
 		return array;
 	}
 }

--- a/src/test/java/org/mastodon/mamut/clustering/ClusterApporientedDemo.java
+++ b/src/test/java/org/mastodon/mamut/clustering/ClusterApporientedDemo.java
@@ -76,27 +76,27 @@ public class ClusterApporientedDemo
 		Cluster completeRandom = algorithm.performClustering( randomDistances, ClusterData.names, new CompleteLinkageStrategy() );
 
 		JPanel averagedFixedPanel = new DendrogramView<>(
-				new Classification<>( Collections.emptyList(), averageFixed, 20d ),
+				new Classification<>( Collections.emptyList(), averageFixed, 20d, randomDistances ),
 				"Average Linkage (Fixed Values)"
 		).getPanel();
 		JPanel singleFixedPanel = new DendrogramView<>(
-				new Classification<>( Collections.emptyList(), singleFixed, 20d ),
+				new Classification<>( Collections.emptyList(), singleFixed, 20d, randomDistances ),
 				"Single Linkage (Fixed Values)"
 		).getPanel();
 		JPanel completeFixedPanel = new DendrogramView<>(
-				new Classification<>( Collections.emptyList(), completeFixed, 20d ),
+				new Classification<>( Collections.emptyList(), completeFixed, 20d, randomDistances ),
 				"Complete Linkage (Fixed Values)"
 		).getPanel();
 		JPanel averagedRandomPanel = new DendrogramView<>(
-				new Classification<>( Collections.emptyList(), averageRandom, 5d ),
+				new Classification<>( Collections.emptyList(), averageRandom, 5d, randomDistances ),
 				"Average Linkage (Random Values)"
 		).getPanel();
 		JPanel singleRandomPanel = new DendrogramView<>(
-				new Classification<>( Collections.emptyList(), singleRandom, 5d ),
+				new Classification<>( Collections.emptyList(), singleRandom, 5d, randomDistances ),
 				"Single Linkage (Random Values)"
 		).getPanel();
 		JPanel completeRandomPanel = new DendrogramView<>(
-				new Classification<>( Collections.emptyList(), completeRandom, 5d ),
+				new Classification<>( Collections.emptyList(), completeRandom, 5d, randomDistances ),
 				"Complete Linkage (Random Values)"
 		).getPanel();
 

--- a/src/test/java/org/mastodon/mamut/clustering/ClusterApporientedDemo.java
+++ b/src/test/java/org/mastodon/mamut/clustering/ClusterApporientedDemo.java
@@ -34,9 +34,11 @@ import com.apporiented.algorithm.clustering.ClusteringAlgorithm;
 import com.apporiented.algorithm.clustering.CompleteLinkageStrategy;
 import com.apporiented.algorithm.clustering.DefaultClusteringAlgorithm;
 import com.apporiented.algorithm.clustering.SingleLinkageStrategy;
+import net.imglib2.util.Util;
 import net.miginfocom.swing.MigLayout;
 import org.mastodon.mamut.clustering.ui.DendrogramView;
 import org.mastodon.mamut.clustering.util.Classification;
+import org.mastodon.mamut.clustering.util.ClusterUtils;
 
 import javax.swing.JFrame;
 import javax.swing.JPanel;
@@ -74,29 +76,30 @@ public class ClusterApporientedDemo
 		Cluster averageRandom = algorithm.performClustering( randomDistances, ClusterData.names, new AverageLinkageStrategy() );
 		Cluster singleRandom = algorithm.performClustering( randomDistances, ClusterData.names, new SingleLinkageStrategy() );
 		Cluster completeRandom = algorithm.performClustering( randomDistances, ClusterData.names, new CompleteLinkageStrategy() );
+		double median = Util.median( ClusterUtils.getUpperTriangle( randomDistances ) );
 
 		JPanel averagedFixedPanel = new DendrogramView<>(
-				new Classification<>( Collections.emptyList(), averageFixed, 20d, randomDistances ),
+				new Classification<>( Collections.emptyList(), averageFixed, 20d, median ),
 				"Average Linkage (Fixed Values)"
 		).getPanel();
 		JPanel singleFixedPanel = new DendrogramView<>(
-				new Classification<>( Collections.emptyList(), singleFixed, 20d, randomDistances ),
+				new Classification<>( Collections.emptyList(), singleFixed, 20d, median ),
 				"Single Linkage (Fixed Values)"
 		).getPanel();
 		JPanel completeFixedPanel = new DendrogramView<>(
-				new Classification<>( Collections.emptyList(), completeFixed, 20d, randomDistances ),
+				new Classification<>( Collections.emptyList(), completeFixed, 20d, median ),
 				"Complete Linkage (Fixed Values)"
 		).getPanel();
 		JPanel averagedRandomPanel = new DendrogramView<>(
-				new Classification<>( Collections.emptyList(), averageRandom, 5d, randomDistances ),
+				new Classification<>( Collections.emptyList(), averageRandom, 5d, median ),
 				"Average Linkage (Random Values)"
 		).getPanel();
 		JPanel singleRandomPanel = new DendrogramView<>(
-				new Classification<>( Collections.emptyList(), singleRandom, 5d, randomDistances ),
+				new Classification<>( Collections.emptyList(), singleRandom, 5d, median ),
 				"Single Linkage (Random Values)"
 		).getPanel();
 		JPanel completeRandomPanel = new DendrogramView<>(
-				new Classification<>( Collections.emptyList(), completeRandom, 5d, randomDistances ),
+				new Classification<>( Collections.emptyList(), completeRandom, 5d, median ),
 				"Complete Linkage (Random Values)"
 		).getPanel();
 

--- a/src/test/java/org/mastodon/mamut/clustering/ui/CustomizedClusterComponentTest.java
+++ b/src/test/java/org/mastodon/mamut/clustering/ui/CustomizedClusterComponentTest.java
@@ -42,7 +42,6 @@ import java.awt.Image;
 import java.awt.image.BufferedImage;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 public class CustomizedClusterComponentTest
 {
@@ -58,7 +57,6 @@ public class CustomizedClusterComponentTest
 						3
 				);
 		Cluster cluster = classification.getRootCluster();
-		assertNotNull( cluster );
 		CustomizedClusterComponent customizedClusterComponent =
 				new CustomizedClusterComponent( cluster, classification.getObjectClassifications() );
 

--- a/src/test/java/org/mastodon/mamut/clustering/ui/DendrogramPanelDemo.java
+++ b/src/test/java/org/mastodon/mamut/clustering/ui/DendrogramPanelDemo.java
@@ -50,6 +50,9 @@ import java.util.Collections;
  */
 public class DendrogramPanelDemo
 {
+	private static final double[][] distances = new double[][] { { 0, 1, 9, 7, 11, 14 }, { 1, 0, 4, 3, 8, 10 }, { 9, 4, 0, 9, 2, 8 },
+			{ 7, 3, 9, 0, 6, 13 }, { 11, 8, 2, 6, 0, 10 }, { 14, 10, 8, 13, 10, 0 } };
+
 	public static void main( String[] args )
 	{
 		JFrame frame = new JFrame();
@@ -59,7 +62,7 @@ public class DendrogramPanelDemo
 
 		JPanel content = new JPanel();
 		Cluster cluster = createSampleCluster();
-		Classification< String > classification = new Classification<>( Collections.emptyList(), cluster, 6d );
+		Classification< String > classification = new Classification<>( Collections.emptyList(), cluster, 6d, distances );
 		DendrogramPanel< String > dp = new DendrogramPanel<>( classification );
 
 		frame.setContentPane( content );
@@ -73,8 +76,6 @@ public class DendrogramPanelDemo
 
 	private static Cluster createSampleCluster()
 	{
-		double[][] distances = new double[][] { { 0, 1, 9, 7, 11, 14 }, { 1, 0, 4, 3, 8, 10 }, { 9, 4, 0, 9, 2, 8 },
-				{ 7, 3, 9, 0, 6, 13 }, { 11, 8, 2, 6, 0, 10 }, { 14, 10, 8, 13, 10, 0 } };
 		String[] names = new String[] { "O1", "O2", "O3", "O4", "O5", "O6" };
 		ClusteringAlgorithm alg = new DefaultClusteringAlgorithm();
 		Cluster cluster = alg.performClustering( distances, names, new AverageLinkageStrategy() );

--- a/src/test/java/org/mastodon/mamut/clustering/ui/DendrogramPanelDemo.java
+++ b/src/test/java/org/mastodon/mamut/clustering/ui/DendrogramPanelDemo.java
@@ -32,7 +32,9 @@ import com.apporiented.algorithm.clustering.AverageLinkageStrategy;
 import com.apporiented.algorithm.clustering.Cluster;
 import com.apporiented.algorithm.clustering.ClusteringAlgorithm;
 import com.apporiented.algorithm.clustering.DefaultClusteringAlgorithm;
+import net.imglib2.util.Util;
 import org.mastodon.mamut.clustering.util.Classification;
+import org.mastodon.mamut.clustering.util.ClusterUtils;
 
 import javax.swing.JFrame;
 import javax.swing.JPanel;
@@ -62,7 +64,8 @@ public class DendrogramPanelDemo
 
 		JPanel content = new JPanel();
 		Cluster cluster = createSampleCluster();
-		Classification< String > classification = new Classification<>( Collections.emptyList(), cluster, 6d, distances );
+		double median = Util.median( ClusterUtils.getUpperTriangle( distances ) );
+		Classification< String > classification = new Classification<>( Collections.emptyList(), cluster, 6d, median );
 		DendrogramPanel< String > dp = new DendrogramPanel<>( classification );
 
 		frame.setContentPane( content );

--- a/src/test/java/org/mastodon/mamut/clustering/ui/DendrogramPanelTest.java
+++ b/src/test/java/org/mastodon/mamut/clustering/ui/DendrogramPanelTest.java
@@ -111,7 +111,6 @@ public class DendrogramPanelTest
 	public void testDendrogramPanelAxisSmallerOne()
 	{
 		Cluster cluster = classification.getRootCluster();
-		assertNotNull( cluster );
 		adaptClusterValues( cluster );
 		DendrogramPanel< String > dendrogramPanel = new DendrogramPanel<>( classification );
 		DendrogramPanel< String >.Axis axis =

--- a/src/test/java/org/mastodon/mamut/clustering/ui/DendrogramViewTest.java
+++ b/src/test/java/org/mastodon/mamut/clustering/ui/DendrogramViewTest.java
@@ -45,7 +45,7 @@ public class DendrogramViewTest
 	{
 		Cluster cluster = new Cluster( "test" );
 		Classification< BranchSpotTree > classification =
-				new Classification<>( Collections.singletonList( Pair.of( null, cluster ) ), null, 0d );
+				new Classification<>( Collections.singletonList( Pair.of( null, cluster ) ), null, 0d, new double[][] { { 0 } } );
 		DendrogramView< BranchSpotTree > dendrogramView = new DendrogramView<>( classification, "test" );
 		DendrogramView< BranchSpotTree > dendrogramViewNull = new DendrogramView<>( null, "test" );
 		assertNotNull( dendrogramView );

--- a/src/test/java/org/mastodon/mamut/clustering/ui/DendrogramViewTest.java
+++ b/src/test/java/org/mastodon/mamut/clustering/ui/DendrogramViewTest.java
@@ -45,7 +45,7 @@ public class DendrogramViewTest
 	{
 		Cluster cluster = new Cluster( "test" );
 		Classification< BranchSpotTree > classification =
-				new Classification<>( Collections.singletonList( Pair.of( null, cluster ) ), null, 0d, new double[][] { { 0 } } );
+				new Classification<>( Collections.singletonList( Pair.of( null, cluster ) ), new Cluster( null ), 0d, 0d );
 		DendrogramView< BranchSpotTree > dendrogramView = new DendrogramView<>( classification, "test" );
 		DendrogramView< BranchSpotTree > dendrogramViewNull = new DendrogramView<>( null, "test" );
 		assertNotNull( dendrogramView );

--- a/src/test/java/org/mastodon/mamut/clustering/util/ClassificationTest.java
+++ b/src/test/java/org/mastodon/mamut/clustering/util/ClassificationTest.java
@@ -1,0 +1,17 @@
+package org.mastodon.mamut.clustering.util;
+
+import org.junit.Test;
+import org.mastodon.mamut.clustering.ClusterData;
+
+import static org.junit.Assert.assertEquals;
+
+public class ClassificationTest
+{
+	@Test
+	public void testGetMedian()
+	{
+		Classification< String > classification = ClusterUtils.getClassificationByClassCount( ClusterData.names, ClusterData.fixedDistances,
+				new AverageLinkageUPGMAStrategy(), 3 );
+		assertEquals( 47, classification.getMedian(), 0d );
+	}
+}

--- a/src/test/java/org/mastodon/mamut/clustering/util/ClassificationTest.java
+++ b/src/test/java/org/mastodon/mamut/clustering/util/ClassificationTest.java
@@ -12,6 +12,6 @@ public class ClassificationTest
 	{
 		Classification< String > classification = ClusterUtils.getClassificationByClassCount( ClusterData.names, ClusterData.fixedDistances,
 				new AverageLinkageUPGMAStrategy(), 3 );
-		assertEquals( 47, classification.getMedian(), 0d );
+		assertEquals( 51, classification.getMedian(), 0d );
 	}
 }

--- a/src/test/java/org/mastodon/mamut/clustering/util/ClusterUtilsTest.java
+++ b/src/test/java/org/mastodon/mamut/clustering/util/ClusterUtilsTest.java
@@ -49,7 +49,6 @@ import java.util.Set;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 
 public class ClusterUtilsTest
@@ -203,7 +202,7 @@ public class ClusterUtilsTest
 		Set< String > expected = new HashSet<>( Arrays.asList( ClusterData.names ) );
 		Set< Set< String > > expectedClasses = new HashSet<>( Collections.singletonList( expected ) );
 		assertEquals( expectedClasses, classification.getClassifiedObjects() );
-		assertNull( classification.getRootCluster() );
+		assertNotNull( classification.getRootCluster() );
 	}
 
 	@Test
@@ -226,7 +225,7 @@ public class ClusterUtilsTest
 				new HashSet<>( Collections.singletonList( "J" ) )
 		) );
 		assertEquals( expectedClasses, classification.getClassifiedObjects() );
-		assertNull( classification.getRootCluster() );
+		assertNotNull( classification.getRootCluster() );
 	}
 
 	@Test
@@ -242,7 +241,6 @@ public class ClusterUtilsTest
 				ClusterUtils
 						.getClassificationByClassCount( names, distances, new AverageLinkageUPGMAStrategy(), 2 );
 		Cluster cluster = classification.getRootCluster();
-		assertNotNull( cluster );
 		Cluster child0 = cluster.getChildren().get( 0 );
 		Cluster child1 = cluster.getChildren().get( 1 );
 		Set< Set< String > > expectedClasses = new HashSet<>( Arrays.asList(
@@ -274,7 +272,6 @@ public class ClusterUtilsTest
 				ClusterUtils
 						.getClassificationByClassCount( names, distances, new AverageLinkageUPGMAStrategy(), 2 );
 		Cluster cluster = classification.getRootCluster();
-		assertNotNull( cluster );
 		Cluster child0 = cluster.getChildren().get( 0 );
 		Cluster child1 = cluster.getChildren().get( 1 );
 		assertEquals( 17.5, cluster.getDistanceValue(), 0d );
@@ -325,7 +322,6 @@ public class ClusterUtilsTest
 				ClusterUtils
 						.getClassificationByClassCount( names, distances, new AverageLinkageWPGMAStrategy(), 2 );
 		Cluster cluster = classification.getRootCluster();
-		assertNotNull( cluster );
 		Cluster child0 = cluster.getChildren().get( 0 );
 		Cluster child1 = cluster.getChildren().get( 1 );
 		Cluster child10 = child1.getChildren().get( 0 );
@@ -351,7 +347,6 @@ public class ClusterUtilsTest
 				ClusterUtils
 						.getClassificationByClassCount( names, distances, new AverageLinkageUPGMAStrategy(), 2 );
 		Cluster cluster = classification.getRootCluster();
-		assertNotNull( cluster );
 		Cluster child0 = cluster.getChildren().get( 0 );
 		Cluster child1 = cluster.getChildren().get( 1 );
 		Cluster child10 = child1.getChildren().get( 0 );

--- a/src/test/java/org/mastodon/mamut/clustering/util/ClusterUtilsTest.java
+++ b/src/test/java/org/mastodon/mamut/clustering/util/ClusterUtilsTest.java
@@ -391,4 +391,43 @@ public class ClusterUtilsTest
 		assertEquals( 0, ClusterUtils.getGlasbeyColors( 0 ).size() );
 	}
 
+	@Test
+	public void testGetUpperTriangle()
+	{
+		double[][] inputMatrix0x0 = new double[ 0 ][ 0 ];
+		double[][] inputMatrix1x1 = new double[][] {
+				{ 0 }
+		};
+		double[][] inputMatrix4x3 = new double[][] {
+				{ 0, 1, 2, 6 },
+				{ 1, 0, 3, 8 },
+				{ 6, 8, 9, 0 }
+		};
+		double[][] inputMatrix2x2 = new double[][] {
+				{ 0, 1 },
+				{ 1, 0 }
+		};
+		double[] expectedResult2x2 = new double[] { 1 };
+		double[][] inputMatrix3x3 = new double[][] {
+				{ 0, 1, 2 },
+				{ 1, 0, 3 },
+				{ 2, 3, 0 }
+		};
+		double[] expectedResult3x3 = new double[] { 1, 2, 3 };
+		double[][] inputMatrix4x4 = new double[][] {
+				{ 0, 1, 2, 6 },
+				{ 1, 0, 3, 8 },
+				{ 2, 3, 0, 9 },
+				{ 6, 8, 9, 0 }
+		};
+		double[] expectedResult4x4 = new double[] { 1, 2, 6, 3, 8, 9 };
+
+		assertEquals( 0, ClusterUtils.getUpperTriangle( null ).length );
+		assertEquals( 0, ClusterUtils.getUpperTriangle( inputMatrix0x0 ).length );
+		assertEquals( 0, ClusterUtils.getUpperTriangle( inputMatrix1x1 ).length );
+		assertThrows( IllegalArgumentException.class, () -> ClusterUtils.getUpperTriangle( inputMatrix4x3 ) );
+		assertArrayEquals( expectedResult2x2, ClusterUtils.getUpperTriangle( inputMatrix2x2 ), 0d );
+		assertArrayEquals( expectedResult3x3, ClusterUtils.getUpperTriangle( inputMatrix3x3 ), 0d );
+		assertArrayEquals( expectedResult4x4, ClusterUtils.getUpperTriangle( inputMatrix4x4 ), 0d );
+	}
 }


### PR DESCRIPTION
This PR adds a median line to the dendrogram view.

The median line represents the median value of the matrix that is underlying the classification represented by the dendrogram.

Additionally some labels for the axis have been added, cf.:
![Unbenannt](https://github.com/mastodon-sc/mastodon-deep-lineage/assets/10515534/142458bd-02a7-4ab5-88d6-8d95c0aa9c7b)




Resolves #52 
