### PR TITLE
Add an optimization for the tree edit distance for the case of binary trees

### DIFF
--- a/src/main/java/org/mastodon/mamut/clustering/config/SimilarityMeasure.java
+++ b/src/main/java/org/mastodon/mamut/clustering/config/SimilarityMeasure.java
@@ -34,8 +34,7 @@ import org.mastodon.mamut.treesimilarity.ZhangUnorderedTreeEditDistance;
 import org.mastodon.mamut.treesimilarity.tree.Tree;
 
 import java.util.NoSuchElementException;
-import java.util.function.BiFunction;
-import java.util.function.BinaryOperator;
+import java.util.function.ToDoubleBiFunction;
 
 public enum SimilarityMeasure implements HasName
 {
@@ -57,13 +56,13 @@ public enum SimilarityMeasure implements HasName
 
 	private final String name;
 
-	private final TriFunction< Tree< Double >, Tree< Double >, BiFunction< Double, Double, Double >, Double > distanceFunction;
+	private final TriFunction< Tree< Double >, Tree< Double >, ToDoubleBiFunction< Double, Double >, Double > distanceFunction;
 
-	private final BinaryOperator< Double > costFunction;
+	private final ToDoubleBiFunction< Double, Double > costFunction;
 
 	SimilarityMeasure( final String name,
-			final TriFunction< Tree< Double >, Tree< Double >, BiFunction< Double, Double, Double >, Double > distanceFunction,
-			final BinaryOperator< Double > costFunction )
+			final TriFunction< Tree< Double >, Tree< Double >, ToDoubleBiFunction< Double, Double >, Double > distanceFunction,
+			final ToDoubleBiFunction< Double, Double > costFunction )
 	{
 		this.name = name;
 		this.distanceFunction = distanceFunction;

--- a/src/main/java/org/mastodon/mamut/treesimilarity/TreeDistances.java
+++ b/src/main/java/org/mastodon/mamut/treesimilarity/TreeDistances.java
@@ -4,8 +4,7 @@ import org.mastodon.mamut.treesimilarity.tree.Tree;
 import org.mastodon.mamut.treesimilarity.tree.TreeUtils;
 
 import javax.annotation.Nullable;
-import java.util.function.BiFunction;
-import java.util.function.BinaryOperator;
+import java.util.function.ToDoubleBiFunction;
 
 /**
  * Utility class for calculating distances between trees.
@@ -24,14 +23,14 @@ public class TreeDistances
 	 *
 	 * @see <a href="https://gitlab.inria.fr/mosaic/treex/-/blob/master/test/test_analysis/test_zhang_labeled_trees.py?ref_type=heads#L99">treex library</a>
 	 */
-	public static final BinaryOperator< Double > LOCAL_ABSOLUTE_COST_FUNCTION = TreeDistances::localAbsoluteCostFunction;
+	public static final ToDoubleBiFunction< Double, Double > LOCAL_ABSOLUTE_COST_FUNCTION = TreeDistances::localAbsoluteCostFunction;
 
 	/**
 	 * Cost function as used in Guignard et al. 2020. It returns the normalized absolute difference between two attributes or 1 if one attribute is {@code null}.
 	 *
 	 * @see <a href="https://www.science.org/doi/suppl/10.1126/science.aar5663/suppl_file/aar5663_guignard_sm.pdf">Guignard et al. (2020) Page 38-39</a>
 	 */
-	public static final BinaryOperator< Double > LOCAL_NORMALIZED_COST_FUNCTION = TreeDistances::localNormalizedCostFunction;
+	public static final ToDoubleBiFunction< Double, Double > LOCAL_NORMALIZED_COST_FUNCTION = TreeDistances::localNormalizedCostFunction;
 
 	/**
 	 * Calculates the normalized Zhang edit distance between two labeled unordered trees.
@@ -46,7 +45,7 @@ public class TreeDistances
 	 * @return The normalized Zhang edit distance between tree1 and tree2.
 	 */
 	public static < T > double normalizedDistance( @Nullable final Tree< T > tree1, final @Nullable Tree< T > tree2,
-			final BiFunction< T, T, Double > costFunction )
+			final ToDoubleBiFunction< T, T > costFunction )
 	{
 		double denominator = ZhangUnorderedTreeEditDistance.distance( tree1, null, costFunction )
 				+ ZhangUnorderedTreeEditDistance.distance( null, tree2, costFunction );
@@ -69,7 +68,7 @@ public class TreeDistances
 	 * @return The average Zhang edit distance between tree1 and tree2.
 	 */
 	public static < T > double averageDistance( @Nullable final Tree< T > tree1, final @Nullable Tree< T > tree2,
-			final BiFunction< T, T, Double > costFunction )
+			final ToDoubleBiFunction< T, T > costFunction )
 	{
 		double denominator = ( double ) TreeUtils.size( tree1 ) + ( double ) TreeUtils.size( tree2 );
 		// NB: avoid division by zero. Two empty trees are considered equal.

--- a/src/main/java/org/mastodon/mamut/treesimilarity/ZhangUnorderedTreeEditDistance.java
+++ b/src/main/java/org/mastodon/mamut/treesimilarity/ZhangUnorderedTreeEditDistance.java
@@ -144,7 +144,7 @@ public class ZhangUnorderedTreeEditDistance< T >
 
 	private final List< Tree< T > > subtrees2;
 
-	private final double[][] attributeDistanceMatrix;
+	private final double[][] costMatrix;
 
 	/**
 	 * Calculates the absolute Zhang edit distance between two labeled unordered trees.
@@ -211,13 +211,13 @@ public class ZhangUnorderedTreeEditDistance< T >
 		subtrees1.forEach( tree -> tree.setId( subtrees1.indexOf( tree ) ) );
 		subtrees2.forEach( tree -> tree.setId( subtrees2.indexOf( tree ) ) );
 
-		attributeDistanceMatrix = new double[ subtrees1.size() ][ subtrees2.size() ];
+		costMatrix = new double[ subtrees1.size() ][ subtrees2.size() ];
 		for ( Tree< T > subtree1 : subtrees1 )
 		{
 			for ( Tree< T > subtree2 : subtrees2 )
 			{
 				double distance = costFunction.apply( subtree1.getAttribute(), subtree2.getAttribute() );
-				attributeDistanceMatrix[ subtree1.getId() ][ subtree2.getId() ] = distance;
+				costMatrix[ subtree1.getId() ][ subtree2.getId() ] = distance;
 			}
 		}
 
@@ -306,7 +306,7 @@ public class ZhangUnorderedTreeEditDistance< T >
 
 	private NodeMapping< T > computeTreeMapping( Tree< T > tree1, Tree< T > tree2 )
 	{
-		double cost = attributeDistanceMatrix[ tree1.getId() ][ tree2.getId() ];
+		double cost = costMatrix[ tree1.getId() ][ tree2.getId() ];
 		NodeMapping< T > attributeMapping = NodeMappings.singleton( cost, tree1, tree2 );
 		if ( tree1.isLeaf() && tree2.isLeaf() )
 			return attributeMapping;

--- a/src/main/java/org/mastodon/mamut/treesimilarity/ZhangUnorderedTreeEditDistance.java
+++ b/src/main/java/org/mastodon/mamut/treesimilarity/ZhangUnorderedTreeEditDistance.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -28,7 +28,6 @@
  */
 package org.mastodon.mamut.treesimilarity;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.mastodon.mamut.treesimilarity.tree.Tree;
 import org.mastodon.mamut.treesimilarity.tree.TreeUtils;
 import org.mastodon.mamut.treesimilarity.util.FlowNetwork;
@@ -43,7 +42,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -136,9 +134,9 @@ public class ZhangUnorderedTreeEditDistance< T >
 
 	private final TreeDetails[] deleteCosts;
 
-	private final Map< Pair< Tree< T >, Tree< T > >, NodeMapping< T > > treeMappings;
+	private final NodeMapping< T >[][] treeMappings;
 
-	private final Map< Pair< Tree< T >, Tree< T > >, NodeMapping< T > > forestMappings;
+	private final NodeMapping< T >[][] forestMappings;
 
 	private final List< Tree< T > > subtrees1;
 
@@ -201,6 +199,7 @@ public class ZhangUnorderedTreeEditDistance< T >
 		return distance;
 	}
 
+	@SuppressWarnings( "unchecked" )
 	private ZhangUnorderedTreeEditDistance( final Tree< T > tree1, final Tree< T > tree2,
 			final BiFunction< T, T, Double > costFunction )
 	{
@@ -224,8 +223,8 @@ public class ZhangUnorderedTreeEditDistance< T >
 		insertCosts = new EditCosts<>( tree2, costFunction, subtrees2.size() ).costs;
 		deleteCosts = new EditCosts<>( tree1, costFunction, subtrees1.size() ).costs;
 
-		treeMappings = new HashMap<>();
-		forestMappings = new HashMap<>();
+		treeMappings = new NodeMapping[ subtrees1.size() ][ subtrees2.size() ];
+		forestMappings = new NodeMapping[ subtrees1.size() ][ subtrees2.size() ];
 	}
 
 	/**
@@ -269,7 +268,7 @@ public class ZhangUnorderedTreeEditDistance< T >
 			logger.trace( "forest insertion[{}] = {}", subtree, insertCosts[ subtree.getId() ].forestCost );
 	}
 
-	private void logDistances( String prefix, Map< Pair< Tree< T >, Tree< T > >, NodeMapping< T > > distances )
+	private void logDistances( String prefix, NodeMapping< T >[][] nodeMappings )
 	{
 		if ( !logger.isTraceEnabled() )
 			return;
@@ -279,7 +278,7 @@ public class ZhangUnorderedTreeEditDistance< T >
 			StringJoiner stringJoiner = new StringJoiner( ", ", "[", "]" );
 			for ( Tree< T > t2 : subtrees2 )
 			{
-				NodeMapping< T > editOperation = distances.get( Pair.of( t1, t2 ) );
+				NodeMapping< T > editOperation = nodeMappings[ t1.getId() ][ t2.getId() ];
 				stringJoiner.add( editOperation == null ? "-" : Double.toString( editOperation.getCost() ) );
 			}
 			logger.trace( "{} distance[{}] = {}", prefix, t1, stringJoiner );
@@ -292,12 +291,11 @@ public class ZhangUnorderedTreeEditDistance< T >
 	 */
 	private NodeMapping< T > treeMapping( Tree< T > tree1, Tree< T > tree2 )
 	{
-		Pair< Tree< T >, Tree< T > > pair = Pair.of( tree1, tree2 );
-		NodeMapping< T > operation = treeMappings.get( pair );
+		NodeMapping< T > operation = treeMappings[ tree1.getId() ][ tree2.getId() ];
 		if ( operation == null )
 		{
 			operation = computeTreeMapping( tree1, tree2 );
-			treeMappings.put( pair, operation );
+			treeMappings[ tree1.getId() ][ tree2.getId() ] = operation;
 		}
 		return operation;
 	}
@@ -332,12 +330,11 @@ public class ZhangUnorderedTreeEditDistance< T >
 	 */
 	private NodeMapping< T > forestMapping( final Tree< T > forest1, final Tree< T > forest2 )
 	{
-		Pair< Tree< T >, Tree< T > > pair = Pair.of( forest1, forest2 );
-		NodeMapping< T > operation = forestMappings.get( pair );
+		NodeMapping< T > operation = forestMappings[ forest1.getId() ][ forest2.getId() ];
 		if ( operation == null )
 		{
 			operation = computeForestMapping( forest1, forest2 );
-			forestMappings.put( pair, operation );
+			forestMappings[ forest1.getId() ][ forest2.getId() ] = operation;
 		}
 		return operation;
 	}

--- a/src/main/java/org/mastodon/mamut/treesimilarity/ZhangUnorderedTreeEditDistance.java
+++ b/src/main/java/org/mastodon/mamut/treesimilarity/ZhangUnorderedTreeEditDistance.java
@@ -47,8 +47,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
-import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.ToDoubleBiFunction;
 import java.util.function.ToIntFunction;
 
 /**
@@ -161,7 +161,7 @@ public class ZhangUnorderedTreeEditDistance< T >
 	 * @return The absolute Zhang edit distance between tree1 and tree2.
 	 */
 	public static < T > double distance( @Nullable final Tree< T > tree1, final @Nullable Tree< T > tree2,
-			final BiFunction< T, T, Double > costFunction )
+			final ToDoubleBiFunction< T, T > costFunction )
 	{
 		if ( costFunction == null )
 			throw new IllegalArgumentException( "The cost function is expected to be non-null, but it is null." );
@@ -188,7 +188,7 @@ public class ZhangUnorderedTreeEditDistance< T >
 	 *
 	 * @return The mapping between nodes.
 	 */
-	public static < T > Map< Tree< T >, Tree< T > > nodeMapping( Tree< T > tree1, Tree< T > tree2, BiFunction< T, T, Double > costFunction )
+	public static < T > Map< Tree< T >, Tree< T > > nodeMapping( Tree< T > tree1, Tree< T > tree2, ToDoubleBiFunction< T, T > costFunction )
 	{
 		if ( tree1 == null || tree2 == null )
 			return Collections.emptyMap();
@@ -197,17 +197,17 @@ public class ZhangUnorderedTreeEditDistance< T >
 		return mapping.asMap();
 	}
 
-	private static < T > double distanceTreeToNull( Tree< T > tree2, BiFunction< T, T, Double > costFunction )
+	private static < T > double distanceTreeToNull( Tree< T > tree2, ToDoubleBiFunction< T, T > costFunction )
 	{
 		double distance = 0;
 		for ( Tree< T > subtree : TreeUtils.listOfSubtrees( tree2 ) )
-			distance += costFunction.apply( null, subtree.getAttribute() );
+			distance += costFunction.applyAsDouble( null, subtree.getAttribute() );
 		return distance;
 	}
 
 	@SuppressWarnings( "unchecked" )
 	private ZhangUnorderedTreeEditDistance( final Tree< T > tree1, final Tree< T > tree2,
-			final BiFunction< T, T, Double > costFunction )
+			final ToDoubleBiFunction< T, T > costFunction )
 	{
 
 		subtrees1 = TreeUtils.listOfSubtrees( tree1 );
@@ -223,7 +223,7 @@ public class ZhangUnorderedTreeEditDistance< T >
 		{
 			for ( Tree< T > subtree2 : subtrees2 )
 			{
-				double distance = costFunction.apply( subtree1.getAttribute(), subtree2.getAttribute() );
+				double distance = costFunction.applyAsDouble( subtree1.getAttribute(), subtree2.getAttribute() );
 				costMatrix[ getTreeIndex1( subtree1 ) ][ getTreeIndex2( subtree2 ) ] = distance;
 			}
 		}
@@ -613,7 +613,7 @@ public class ZhangUnorderedTreeEditDistance< T >
 
 	private static class EditCosts< T >
 	{
-		private final BiFunction< T, T, Double > costFunction;
+		private final ToDoubleBiFunction< T, T > costFunction;
 
 		private final TreeDetails[] costs;
 
@@ -644,7 +644,7 @@ public class ZhangUnorderedTreeEditDistance< T >
 		 * @param tree the tree or forest to compute the change costs for
 		 * @param costFunction costFunction
 		 */
-		private EditCosts( final Tree< T > tree, final BiFunction< T, T, Double > costFunction, final int size,
+		private EditCosts( final Tree< T > tree, final ToDoubleBiFunction< T, T > costFunction, final int size,
 				final ToIntFunction< Tree< T > > treeToIndexFunction
 		)
 		{
@@ -665,7 +665,7 @@ public class ZhangUnorderedTreeEditDistance< T >
 					cost += costs[ treeToIndexFunction.applyAsInt( child ) ].treeCost;
 				}
 			}
-			TreeDetails treeDetails = new TreeDetails( cost + costFunction.apply( tree.getAttribute(), null ), cost );
+			TreeDetails treeDetails = new TreeDetails( cost + costFunction.applyAsDouble( tree.getAttribute(), null ), cost );
 			costs[ treeToIndexFunction.applyAsInt( tree ) ] = treeDetails;
 		}
 	}

--- a/src/main/java/org/mastodon/mamut/treesimilarity/ZhangUnorderedTreeEditDistance.java
+++ b/src/main/java/org/mastodon/mamut/treesimilarity/ZhangUnorderedTreeEditDistance.java
@@ -144,7 +144,7 @@ public class ZhangUnorderedTreeEditDistance< T >
 
 	private final List< Tree< T > > subtrees2;
 
-	private final Map< Pair< Tree< T >, Tree< T > >, Double > attributeDistances;
+	private final double[][] attributeDistanceMatrix;
 
 	/**
 	 * Calculates the absolute Zhang edit distance between two labeled unordered trees.
@@ -208,13 +208,16 @@ public class ZhangUnorderedTreeEditDistance< T >
 		subtrees1 = TreeUtils.listOfSubtrees( tree1 );
 		subtrees2 = TreeUtils.listOfSubtrees( tree2 );
 
-		attributeDistances = new HashMap<>();
+		subtrees1.forEach( tree -> tree.setId( subtrees1.indexOf( tree ) ) );
+		subtrees2.forEach( tree -> tree.setId( subtrees2.indexOf( tree ) ) );
+
+		attributeDistanceMatrix = new double[ subtrees1.size() ][ subtrees2.size() ];
 		for ( Tree< T > subtree1 : subtrees1 )
 		{
 			for ( Tree< T > subtree2 : subtrees2 )
 			{
-				attributeDistances.put( Pair.of( subtree1, subtree2 ),
-						costFunction.apply( subtree1.getAttribute(), subtree2.getAttribute() ) );
+				double distance = costFunction.apply( subtree1.getAttribute(), subtree2.getAttribute() );
+				attributeDistanceMatrix[ subtree1.getId() ][ subtree2.getId() ] = distance;
 			}
 		}
 
@@ -303,7 +306,8 @@ public class ZhangUnorderedTreeEditDistance< T >
 
 	private NodeMapping< T > computeTreeMapping( Tree< T > tree1, Tree< T > tree2 )
 	{
-		NodeMapping< T > attributeMapping = NodeMappings.singleton( attributeDistances.get( Pair.of( tree1, tree2 ) ), tree1, tree2 );
+		double cost = attributeDistanceMatrix[ tree1.getId() ][ tree2.getId() ];
+		NodeMapping< T > attributeMapping = NodeMappings.singleton( cost, tree1, tree2 );
 		if ( tree1.isLeaf() && tree2.isLeaf() )
 			return attributeMapping;
 

--- a/src/main/java/org/mastodon/mamut/treesimilarity/ZhangUnorderedTreeEditDistance.java
+++ b/src/main/java/org/mastodon/mamut/treesimilarity/ZhangUnorderedTreeEditDistance.java
@@ -238,8 +238,6 @@ public class ZhangUnorderedTreeEditDistance< T >
 	 */
 	private double compute( final Tree< T > tree1, final Tree< T > tree2 )
 	{
-		treeMappings.clear();
-		forestMappings.clear();
 		double distance = treeMapping( tree1, tree2 ).getCost();
 
 		log();

--- a/src/main/java/org/mastodon/mamut/treesimilarity/ZhangUnorderedTreeEditDistance.java
+++ b/src/main/java/org/mastodon/mamut/treesimilarity/ZhangUnorderedTreeEditDistance.java
@@ -44,6 +44,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
@@ -442,13 +443,76 @@ public class ZhangUnorderedTreeEditDistance< T >
 		return best;
 	}
 
-	private NodeMapping< T > minCostMaxFlow( final Tree< T > forest1, final Tree< T > forest2 )
+	private NodeMapping< T > minCostMaxFlow( final Tree< T > forestA, final Tree< T > forestB )
+	{
+		Collection< Tree< T > > childrenForestA = forestA.getChildren();
+		Collection< Tree< T > > childrenForestB = forestB.getChildren();
+
+		List< NodeMapping< T > > childMappings;
+		boolean isBinaryTreeComparison = childrenForestA.size() == 2 && childrenForestB.size() == 2;
+		if ( isBinaryTreeComparison )
+			childMappings = minCostMaxFlowBinary( childrenForestA, childrenForestB );
+		else
+			childMappings = minCostMaxFlowNonBinary( childrenForestA, childrenForestB );
+
+		return NodeMappings.compose( childMappings );
+	}
+
+	/**
+	 * Returns the best mapping for binary trees.
+	 * <br>
+	 * For the case of two binary trees / forests, the flow network can be simplified by removing the "empty" nodes.
+	 * <br>
+	 * The remaining flow network can be visualized as follows (capacities annotated with 1):
+	 * <pre>
+	 *                   1
+	 *                A1 --- B1
+	 *               /\      /\
+	 *             1/ 1\    /1 \1
+	 *             /    \  /    \
+	 *     source  \     \/      \    sink
+	 *              \    /\      /
+	 *              1\  /  \    /1
+	 *                \/    \  /
+	 *               A2 --- B2
+	 *                   1
+	 * </pre>
+	 * For this simplified network, the "parallel" and "cross" costs can be calculated directly by summing the costs of the corresponding edges.
+	 * <br>
+	 * The best mapping is then determined by comparing the "parallel" and "cross" costs.
+	 * @param childrenForestA The children of the first forest.
+	 * @param childrenForestB The children of the second forest.
+	 * @return The best mapping for binary trees.
+	 */
+	private List< NodeMapping< T > > minCostMaxFlowBinary( final Collection< Tree< T > > childrenForestA,
+			final Collection< Tree< T > > childrenForestB )
+	{
+		final Iterator< Tree< T > > forestAIterator = childrenForestA.iterator();
+		Tree< T > forestAChild1 = forestAIterator.next();
+		Tree< T > forestAChild2 = forestAIterator.next();
+
+		final Iterator< Tree< T > > forestBIterator = childrenForestB.iterator();
+		Tree< T > forestBChild1 = forestBIterator.next();
+		Tree< T > forestBChild2 = forestBIterator.next();
+
+		NodeMapping< T > mappingA1B1 = treeMapping( forestAChild1, forestBChild1 );
+		NodeMapping< T > mappingA2B2 = treeMapping( forestAChild2, forestBChild2 );
+		NodeMapping< T > mappingA1B2 = treeMapping( forestAChild1, forestBChild2 );
+		NodeMapping< T > mappingA2B1 = treeMapping( forestAChild2, forestBChild1 );
+
+		double parallelCosts = mappingA1B1.getCost() + mappingA2B2.getCost();
+		double crossCosts = mappingA1B2.getCost() + mappingA2B1.getCost();
+
+		if ( parallelCosts <= crossCosts )
+			return Arrays.asList( mappingA1B1, mappingA2B2 );
+		else
+			return Arrays.asList( mappingA1B2, mappingA2B1 );
+	}
+
+	private List< NodeMapping< T > > minCostMaxFlowNonBinary( final Collection< Tree< T > > childrenForest1,
+			final Collection< Tree< T > > childrenForest2 )
 	{
 		// Construction of graph for max flow min cost algorithm
-
-		Collection< Tree< T > > childrenForest1 = forest1.getChildren();
-		Collection< Tree< T > > childrenForest2 = forest2.getChildren();
-
 		String source = "source";
 		String sink = "sink";
 		String emptyTree1 = "empty1";
@@ -458,7 +522,7 @@ public class ZhangUnorderedTreeEditDistance< T >
 
 		network.solveMaxFlowMinCost( source, sink );
 
-		ArrayList< NodeMapping< T > > childMappings = new ArrayList<>();
+		List< NodeMapping< T > > childMappings = new ArrayList<>();
 
 		for ( Tree< T > child1 : childrenForest1 )
 			if ( isFlowEqualToOne( network.getFlow( child1, emptyTree2 ) ) )
@@ -472,8 +536,7 @@ public class ZhangUnorderedTreeEditDistance< T >
 			for ( Tree< T > child2 : childrenForest2 )
 				if ( isFlowEqualToOne( network.getFlow( child1, child2 ) ) )
 					childMappings.add( treeMapping( child1, child2 ) );
-
-		return NodeMappings.compose( childMappings );
+		return childMappings;
 	}
 
 	private FlowNetwork buildFlowNetwork(

--- a/src/main/java/org/mastodon/mamut/treesimilarity/ZhangUnorderedTreeEditDistance.java
+++ b/src/main/java/org/mastodon/mamut/treesimilarity/ZhangUnorderedTreeEditDistance.java
@@ -138,7 +138,7 @@ public class ZhangUnorderedTreeEditDistance< T >
 
 	private final Map< Pair< Tree< T >, Tree< T > >, NodeMapping< T > > treeMappings;
 
-	private final Map< Pair< Tree< T >, Tree< T > >, NodeMapping< T > > forestDistances;
+	private final Map< Pair< Tree< T >, Tree< T > >, NodeMapping< T > > forestMappings;
 
 	private final List< Tree< T > > subtrees1;
 
@@ -222,7 +222,7 @@ public class ZhangUnorderedTreeEditDistance< T >
 		deleteCosts = new EditCosts<>( tree1, costFunction ).costs;
 
 		treeMappings = new HashMap<>();
-		forestDistances = new HashMap<>();
+		forestMappings = new HashMap<>();
 	}
 
 	/**
@@ -236,7 +236,7 @@ public class ZhangUnorderedTreeEditDistance< T >
 	private double compute( final Tree< T > tree1, final Tree< T > tree2 )
 	{
 		treeMappings.clear();
-		forestDistances.clear();
+		forestMappings.clear();
 		double distance = treeMapping( tree1, tree2 ).getCost();
 
 		log();
@@ -249,7 +249,7 @@ public class ZhangUnorderedTreeEditDistance< T >
 		if ( !logger.isTraceEnabled() )
 			return;
 		logDistances( "tree", treeMappings );
-		logDistances( "forest", forestDistances );
+		logDistances( "forest", forestMappings );
 
 		logger.trace( "tree deletion costs (tree1):" );
 		for ( Tree< T > subtree : subtrees1 )
@@ -331,11 +331,11 @@ public class ZhangUnorderedTreeEditDistance< T >
 	private NodeMapping< T > forestMapping( final Tree< T > forest1, final Tree< T > forest2 )
 	{
 		Pair< Tree< T >, Tree< T > > pair = Pair.of( forest1, forest2 );
-		NodeMapping< T > operation = forestDistances.get( pair );
+		NodeMapping< T > operation = forestMappings.get( pair );
 		if ( operation == null )
 		{
 			operation = computeForestMapping( forest1, forest2 );
-			forestDistances.put( pair, operation );
+			forestMappings.put( pair, operation );
 		}
 		return operation;
 	}

--- a/src/main/java/org/mastodon/mamut/treesimilarity/ZhangUnorderedTreeEditDistance.java
+++ b/src/main/java/org/mastodon/mamut/treesimilarity/ZhangUnorderedTreeEditDistance.java
@@ -132,9 +132,9 @@ public class ZhangUnorderedTreeEditDistance< T >
 {
 	private static final Logger logger = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
 
-	private final Map< Tree< T >, TreeDetails > insertCosts;
+	private final TreeDetails[] insertCosts;
 
-	private final Map< Tree< T >, TreeDetails > deleteCosts;
+	private final TreeDetails[] deleteCosts;
 
 	private final Map< Pair< Tree< T >, Tree< T > >, NodeMapping< T > > treeMappings;
 
@@ -221,8 +221,8 @@ public class ZhangUnorderedTreeEditDistance< T >
 			}
 		}
 
-		insertCosts = new EditCosts<>( tree2, costFunction ).costs;
-		deleteCosts = new EditCosts<>( tree1, costFunction ).costs;
+		insertCosts = new EditCosts<>( tree2, costFunction, subtrees2.size() ).costs;
+		deleteCosts = new EditCosts<>( tree1, costFunction, subtrees1.size() ).costs;
 
 		treeMappings = new HashMap<>();
 		forestMappings = new HashMap<>();
@@ -256,19 +256,19 @@ public class ZhangUnorderedTreeEditDistance< T >
 
 		logger.trace( "tree deletion costs (tree1):" );
 		for ( Tree< T > subtree : subtrees1 )
-			logger.trace( "tree deletion[{}] = {}", subtree, deleteCosts.get( subtree ).treeCost );
+			logger.trace( "tree deletion[{}] = {}", subtree, deleteCosts[ subtree.getId() ].treeCost );
 
 		logger.trace( "forest deletion costs (tree1):" );
 		for ( Tree< T > subtree : subtrees1 )
-			logger.trace( "forest deletion[{}] = {}", subtree, deleteCosts.get( subtree ).forestCost );
+			logger.trace( "forest deletion[{}] = {}", subtree, deleteCosts[ subtree.getId() ].forestCost );
 
 		logger.trace( "tree insertion costs (tree2):" );
 		for ( Tree< T > subtree : subtrees2 )
-			logger.trace( "tree insertion[{}] = {}", subtree, insertCosts.get( subtree ).treeCost );
+			logger.trace( "tree insertion[{}] = {}", subtree, insertCosts[ subtree.getId() ].treeCost );
 
 		logger.trace( "forest insertion costs (tree2):" );
 		for ( Tree< T > subtree : subtrees2 )
-			logger.trace( "forest insertion[{}] = {}", subtree, insertCosts.get( subtree ).forestCost );
+			logger.trace( "forest insertion[{}] = {}", subtree, insertCosts[ subtree.getId() ].forestCost );
 	}
 
 	private void logDistances( String prefix, Map< Pair< Tree< T >, Tree< T > >, NodeMapping< T > > distances )
@@ -353,10 +353,10 @@ public class ZhangUnorderedTreeEditDistance< T >
 			throw new IllegalArgumentException( "The given trees are both leaves and thus they are both not forests." );
 
 		if ( forest1IsLeaf )
-			return NodeMappings.empty( insertCosts.get( forest2 ).forestCost );
+			return NodeMappings.empty( insertCosts[ forest2.getId() ].forestCost );
 
 		if ( forest2IsLeaf )
-			return NodeMappings.empty( deleteCosts.get( forest1 ).forestCost );
+			return NodeMappings.empty( deleteCosts[ forest1.getId() ].forestCost );
 
 		NodeMapping< T > forestInsertCosts = forestInsertMapping( forest1, forest2 );
 		NodeMapping< T > forestDeleteCosts = forestDeleteMapping( forest1, forest2 );
@@ -372,10 +372,10 @@ public class ZhangUnorderedTreeEditDistance< T >
 	 */
 	private NodeMapping< T > insertOperationMapping( Tree< T > tree1, Tree< T > tree2 )
 	{
-		double insertCostTree2 = insertCosts.get( tree2 ).treeCost;
+		double insertCostTree2 = insertCosts[ tree2.getId() ].treeCost;
 		return findBestMapping( tree2.getChildren(), child ->
 		{
-			NodeMapping< T > insertMapping = NodeMappings.empty( insertCostTree2 - this.insertCosts.get( child ).treeCost );
+			NodeMapping< T > insertMapping = NodeMappings.empty( insertCostTree2 - insertCosts[ child.getId() ].treeCost );
 			NodeMapping< T > childMapping = treeMapping( tree1, child );
 			return NodeMappings.compose( insertMapping, childMapping );
 		} );
@@ -389,10 +389,10 @@ public class ZhangUnorderedTreeEditDistance< T >
 	 */
 	private NodeMapping< T > deleteOperationMapping( Tree< T > tree1, Tree< T > tree2 )
 	{
-		double deleteCostTree1 = deleteCosts.get( tree1 ).treeCost;
+		double deleteCostTree1 = deleteCosts[ tree1.getId() ].treeCost;
 		return findBestMapping( tree1.getChildren(), child ->
 		{
-			NodeMapping< T > deleteMapping = NodeMappings.empty( deleteCostTree1 - this.deleteCosts.get( child ).treeCost );
+			NodeMapping< T > deleteMapping = NodeMappings.empty( deleteCostTree1 - deleteCosts[ child.getId() ].treeCost );
 			NodeMapping< T > childMapping = treeMapping( child, tree2 );
 			return NodeMappings.compose( deleteMapping, childMapping );
 		} );
@@ -405,10 +405,10 @@ public class ZhangUnorderedTreeEditDistance< T >
 	private NodeMapping< T > forestInsertMapping( Tree< T > forest1, Tree< T > forest2 )
 	{
 		// NB: this method should not be called on leaves.
-		double insertCostForest2 = insertCosts.get( forest2 ).forestCost;
+		double insertCostForest2 = insertCosts[ forest2.getId() ].forestCost;
 		return findBestMapping( forest2.getChildren(), child ->
 		{
-			NodeMapping< T > insertMapping = NodeMappings.empty( insertCostForest2 - this.insertCosts.get( child ).forestCost );
+			NodeMapping< T > insertMapping = NodeMappings.empty( insertCostForest2 - insertCosts[ child.getId() ].forestCost );
 			NodeMapping< T > childMapping = forestMapping( forest1, child );
 			return NodeMappings.compose( insertMapping, childMapping );
 		} );
@@ -421,10 +421,10 @@ public class ZhangUnorderedTreeEditDistance< T >
 	private NodeMapping< T > forestDeleteMapping( Tree< T > forest1, Tree< T > forest2 )
 	{
 		// NB: this method should not be called on leaves.
-		double deleteCostForest1 = deleteCosts.get( forest1 ).forestCost;
+		double deleteCostForest1 = deleteCosts[ forest1.getId() ].forestCost;
 		return findBestMapping( forest1.getChildren(), child ->
 		{
-			NodeMapping< T > deleteMapping = NodeMappings.empty( deleteCostForest1 - this.deleteCosts.get( child ).forestCost );
+			NodeMapping< T > deleteMapping = NodeMappings.empty( deleteCostForest1 - deleteCosts[ child.getId() ].forestCost );
 			NodeMapping< T > childMapping = forestMapping( child, forest2 );
 			return NodeMappings.compose( deleteMapping, childMapping );
 		} );
@@ -530,11 +530,11 @@ public class ZhangUnorderedTreeEditDistance< T >
 
 		for ( Tree< T > child1 : childrenForest1 )
 			if ( isFlowEqualToOne( network.getFlow( child1, emptyTree2 ) ) )
-				childMappings.add( NodeMappings.empty( deleteCosts.get( child1 ).treeCost ) );
+				childMappings.add( NodeMappings.empty( deleteCosts[ child1.getId() ].treeCost ) );
 
 		for ( Tree< T > child2 : childrenForest2 )
 			if ( isFlowEqualToOne( network.getFlow( emptyTree1, child2 ) ) )
-				childMappings.add( NodeMappings.empty( insertCosts.get( child2 ).treeCost ) );
+				childMappings.add( NodeMappings.empty( insertCosts[ child2.getId() ].treeCost ) );
 
 		for ( Tree< T > child1 : childrenForest1 )
 			for ( Tree< T > child2 : childrenForest2 )
@@ -562,7 +562,7 @@ public class ZhangUnorderedTreeEditDistance< T >
 		for ( Tree< T > child1 : childrenForest1 )
 		{
 			network.addEdge( source, child1, 1, 0 );
-			network.addEdge( child1, emptyTree2, 1, deleteCosts.get( child1 ).treeCost );
+			network.addEdge( child1, emptyTree2, 1, deleteCosts[ child1.getId() ].treeCost );
 			for ( Tree< T > child2 : childrenForest2 )
 				network.addEdge( child1, child2, 1, treeMapping( child1, child2 ).getCost() );
 		}
@@ -570,7 +570,7 @@ public class ZhangUnorderedTreeEditDistance< T >
 		for ( Tree< T > child2 : childrenForest2 )
 		{
 			network.addEdge( child2, sink, 1, 0 );
-			network.addEdge( emptyTree1, child2, 1, insertCosts.get( child2 ).treeCost );
+			network.addEdge( emptyTree1, child2, 1, insertCosts[ child2.getId() ].treeCost );
 		}
 		return network;
 	}
@@ -602,7 +602,7 @@ public class ZhangUnorderedTreeEditDistance< T >
 	{
 		private final BiFunction< T, T, Double > costFunction;
 
-		private final Map< Tree< T >, TreeDetails > costs;
+		private final TreeDetails[] costs;
 
 		/**
 		 * Compute the costs of deleting or inserting a tree or a forest.
@@ -629,10 +629,10 @@ public class ZhangUnorderedTreeEditDistance< T >
 		 * @param tree the tree or forest to compute the change costs for
 		 * @param costFunction costFunction
 		 */
-		private EditCosts( final Tree< T > tree, final BiFunction< T, T, Double > costFunction )
+		private EditCosts( final Tree< T > tree, final BiFunction< T, T, Double > costFunction, final int size )
 		{
 			this.costFunction = costFunction;
-			this.costs = new HashMap<>();
+			this.costs = new TreeDetails[ size ];
 			computeChangeCosts( tree );
 		}
 
@@ -644,10 +644,11 @@ public class ZhangUnorderedTreeEditDistance< T >
 				for ( Tree< T > child : tree.getChildren() )
 				{
 					computeChangeCosts( child );
-					cost += costs.get( child ).treeCost;
+					cost += costs[ child.getId() ].treeCost;
 				}
 			}
-			costs.put( tree, new TreeDetails( cost + costFunction.apply( tree.getAttribute(), null ), cost ) );
+			TreeDetails treeDetails = new TreeDetails( cost + costFunction.apply( tree.getAttribute(), null ), cost );
+			costs[ tree.getId() ] = treeDetails;
 		}
 	}
 

--- a/src/main/java/org/mastodon/mamut/treesimilarity/ZhangUnorderedTreeEditDistance.java
+++ b/src/main/java/org/mastodon/mamut/treesimilarity/ZhangUnorderedTreeEditDistance.java
@@ -136,7 +136,7 @@ public class ZhangUnorderedTreeEditDistance< T >
 
 	private final Map< Tree< T >, TreeDetails > deleteCosts;
 
-	private final Map< Pair< Tree< T >, Tree< T > >, NodeMapping< T > > treeDistances;
+	private final Map< Pair< Tree< T >, Tree< T > >, NodeMapping< T > > treeMappings;
 
 	private final Map< Pair< Tree< T >, Tree< T > >, NodeMapping< T > > forestDistances;
 
@@ -221,7 +221,7 @@ public class ZhangUnorderedTreeEditDistance< T >
 		insertCosts = new EditCosts<>( tree2, costFunction ).costs;
 		deleteCosts = new EditCosts<>( tree1, costFunction ).costs;
 
-		treeDistances = new HashMap<>();
+		treeMappings = new HashMap<>();
 		forestDistances = new HashMap<>();
 	}
 
@@ -235,7 +235,7 @@ public class ZhangUnorderedTreeEditDistance< T >
 	 */
 	private double compute( final Tree< T > tree1, final Tree< T > tree2 )
 	{
-		treeDistances.clear();
+		treeMappings.clear();
 		forestDistances.clear();
 		double distance = treeMapping( tree1, tree2 ).getCost();
 
@@ -248,7 +248,7 @@ public class ZhangUnorderedTreeEditDistance< T >
 	{
 		if ( !logger.isTraceEnabled() )
 			return;
-		logDistances( "tree", treeDistances );
+		logDistances( "tree", treeMappings );
 		logDistances( "forest", forestDistances );
 
 		logger.trace( "tree deletion costs (tree1):" );
@@ -292,11 +292,11 @@ public class ZhangUnorderedTreeEditDistance< T >
 	private NodeMapping< T > treeMapping( Tree< T > tree1, Tree< T > tree2 )
 	{
 		Pair< Tree< T >, Tree< T > > pair = Pair.of( tree1, tree2 );
-		NodeMapping< T > operation = treeDistances.get( pair );
+		NodeMapping< T > operation = treeMappings.get( pair );
 		if ( operation == null )
 		{
 			operation = computeTreeMapping( tree1, tree2 );
-			treeDistances.put( pair, operation );
+			treeMappings.put( pair, operation );
 		}
 		return operation;
 	}

--- a/src/main/java/org/mastodon/mamut/treesimilarity/tree/BranchSpotTree.java
+++ b/src/main/java/org/mastodon/mamut/treesimilarity/tree/BranchSpotTree.java
@@ -44,6 +44,8 @@ import java.util.function.Supplier;
  */
 public class BranchSpotTree implements Tree< Double >
 {
+	private int id;
+
 	private final BranchSpot branchSpot;
 
 	private final int endTimepoint;
@@ -154,5 +156,17 @@ public class BranchSpotTree implements Tree< Double >
 			else
 				return "";
 		}
+	}
+
+	@Override
+	public int getId()
+	{
+		return id;
+	}
+
+	@Override
+	public void setId( int id )
+	{
+		this.id = id;
 	}
 }

--- a/src/main/java/org/mastodon/mamut/treesimilarity/tree/BranchSpotTree.java
+++ b/src/main/java/org/mastodon/mamut/treesimilarity/tree/BranchSpotTree.java
@@ -46,8 +46,6 @@ public class BranchSpotTree implements Tree< Double >
 {
 	private final BranchSpot branchSpot;
 
-	private final int endTimepoint;
-
 	private final Collection< Tree< Double > > children;
 
 	private final LabelSupplier labelSupplier;
@@ -73,7 +71,6 @@ public class BranchSpotTree implements Tree< Double >
 			throw new IllegalArgumentException( "The first timepoint of the given branchSpot " + branchSpot.getFirstTimePoint()
 					+ " is greater than the endTimepoint (" + endTimepoint + ")." );
 		this.branchSpot = branchSpot;
-		this.endTimepoint = endTimepoint;
 		this.children = new ArrayList<>();
 		this.labelSupplier = new LabelSupplier( model );
 		this.attribute = ( double ) BranchSpotFeatureUtils.branchDuration( branchSpot, endTimepoint );
@@ -82,8 +79,8 @@ public class BranchSpotTree implements Tree< Double >
 			BranchSpot child = branchLink.getTarget();
 			if ( branchSpot.equals( child ) )
 				continue;
-			if ( child.getFirstTimePoint() <= this.endTimepoint )
-				this.children.add( new BranchSpotTree( child, this.endTimepoint, model ) );
+			if ( child.getFirstTimePoint() <= endTimepoint )
+				this.children.add( new BranchSpotTree( child, endTimepoint, model ) );
 		}
 	}
 

--- a/src/main/java/org/mastodon/mamut/treesimilarity/tree/BranchSpotTree.java
+++ b/src/main/java/org/mastodon/mamut/treesimilarity/tree/BranchSpotTree.java
@@ -52,6 +52,8 @@ public class BranchSpotTree implements Tree< Double >
 
 	private final LabelSupplier labelSupplier;
 
+	private final Double attribute;
+
 	public BranchSpotTree( final BranchSpot branchSpot, final int endTimepoint )
 	{
 		this( branchSpot, endTimepoint, null );
@@ -74,6 +76,7 @@ public class BranchSpotTree implements Tree< Double >
 		this.endTimepoint = endTimepoint;
 		this.children = new ArrayList<>();
 		this.labelSupplier = new LabelSupplier( model );
+		this.attribute = ( double ) BranchSpotFeatureUtils.branchDuration( branchSpot, endTimepoint );
 		for ( BranchLink branchLink : branchSpot.outgoingEdges() )
 		{
 			BranchSpot child = branchLink.getTarget();
@@ -93,7 +96,7 @@ public class BranchSpotTree implements Tree< Double >
 	@Override
 	public Double getAttribute()
 	{
-		return ( double ) BranchSpotFeatureUtils.branchDuration( branchSpot, endTimepoint );
+		return attribute;
 	}
 
 	public BranchSpot getBranchSpot()

--- a/src/main/java/org/mastodon/mamut/treesimilarity/tree/BranchSpotTree.java
+++ b/src/main/java/org/mastodon/mamut/treesimilarity/tree/BranchSpotTree.java
@@ -44,8 +44,6 @@ import java.util.function.Supplier;
  */
 public class BranchSpotTree implements Tree< Double >
 {
-	private int id;
-
 	private final BranchSpot branchSpot;
 
 	private final int endTimepoint;
@@ -156,17 +154,5 @@ public class BranchSpotTree implements Tree< Double >
 			else
 				return "";
 		}
-	}
-
-	@Override
-	public int getId()
-	{
-		return id;
-	}
-
-	@Override
-	public void setId( int id )
-	{
-		this.id = id;
 	}
 }

--- a/src/main/java/org/mastodon/mamut/treesimilarity/tree/SimpleTree.java
+++ b/src/main/java/org/mastodon/mamut/treesimilarity/tree/SimpleTree.java
@@ -38,6 +38,7 @@ import java.util.Collection;
  */
 public class SimpleTree< T > implements Tree< T >
 {
+	private int id;
 
 	private final Collection< Tree< T > > children;
 
@@ -89,5 +90,17 @@ public class SimpleTree< T > implements Tree< T >
 	public String toString()
 	{
 		return getClass().getSimpleName() + "@" + hashCode();
+	}
+
+	@Override
+	public int getId()
+	{
+		return id;
+	}
+
+	@Override
+	public void setId( int id )
+	{
+		this.id = id;
 	}
 }

--- a/src/main/java/org/mastodon/mamut/treesimilarity/tree/SimpleTree.java
+++ b/src/main/java/org/mastodon/mamut/treesimilarity/tree/SimpleTree.java
@@ -38,8 +38,6 @@ import java.util.Collection;
  */
 public class SimpleTree< T > implements Tree< T >
 {
-	private int id;
-
 	private final Collection< Tree< T > > children;
 
 	private final T attribute;
@@ -90,17 +88,5 @@ public class SimpleTree< T > implements Tree< T >
 	public String toString()
 	{
 		return getClass().getSimpleName() + "@" + hashCode();
-	}
-
-	@Override
-	public int getId()
-	{
-		return id;
-	}
-
-	@Override
-	public void setId( int id )
-	{
-		this.id = id;
 	}
 }

--- a/src/main/java/org/mastodon/mamut/treesimilarity/tree/Tree.java
+++ b/src/main/java/org/mastodon/mamut/treesimilarity/tree/Tree.java
@@ -59,16 +59,4 @@ public interface Tree< T >
 	{
 		return getChildren().isEmpty();
 	}
-
-	/**
-	 * Gets the id of this {@link Tree}.
-	 * @return the id.
-	 */
-	int getId();
-
-	/**
-	 * Sets the id of this {@link Tree}.
-	 * @param id the id.
-	 */
-	void setId( int id );
 }

--- a/src/main/java/org/mastodon/mamut/treesimilarity/tree/Tree.java
+++ b/src/main/java/org/mastodon/mamut/treesimilarity/tree/Tree.java
@@ -59,4 +59,16 @@ public interface Tree< T >
 	{
 		return getChildren().isEmpty();
 	}
+
+	/**
+	 * Gets the id of this {@link Tree}.
+	 * @return the id.
+	 */
+	int getId();
+
+	/**
+	 * Sets the id of this {@link Tree}.
+	 * @param id the id.
+	 */
+	void setId( int id );
 }

--- a/src/main/java/org/mastodon/mamut/treesimilarity/util/NodeMappings.java
+++ b/src/main/java/org/mastodon/mamut/treesimilarity/util/NodeMappings.java
@@ -89,7 +89,10 @@ public class NodeMappings
 	 */
 	public static < T > NodeMapping< T > compose( List< NodeMapping< T > > children )
 	{
-		return new ComposedNodeMapping<>( children );
+		double composedCost = 0;
+		for ( NodeMapping< T > child : children )
+			composedCost += child.getCost();
+		return new ComposedNodeMapping<>( children, composedCost );
 	}
 
 	private abstract static class AbstractNodeMapping< T > implements NodeMapping< T >
@@ -146,9 +149,9 @@ public class NodeMappings
 	{
 		private final List< NodeMapping< T > > children;
 
-		private ComposedNodeMapping( List< NodeMapping< T > > children )
+		private ComposedNodeMapping( List< NodeMapping< T > > children, double cost )
 		{
-			super( children.stream().mapToDouble( NodeMapping::getCost ).sum() );
+			super( cost );
 			this.children = children;
 		}
 

--- a/src/test/java/org/mastodon/mamut/treesimilarity/TreeDistancesTest.java
+++ b/src/test/java/org/mastodon/mamut/treesimilarity/TreeDistancesTest.java
@@ -5,14 +5,14 @@ import org.mastodon.mamut.treesimilarity.tree.SimpleTree;
 import org.mastodon.mamut.treesimilarity.tree.SimpleTreeExamples;
 import org.mastodon.mamut.treesimilarity.tree.Tree;
 
-import java.util.function.BiFunction;
+import java.util.function.ToDoubleBiFunction;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class TreeDistancesTest
 {
 
-	private final static BiFunction< Double, Double, Double > defaultCosts = TreeDistances.LOCAL_ABSOLUTE_COST_FUNCTION;
+	private final static ToDoubleBiFunction< Double, Double > defaultCosts = TreeDistances.LOCAL_ABSOLUTE_COST_FUNCTION;
 
 	@Test
 	void testNormalizedDistance()

--- a/src/test/java/org/mastodon/mamut/treesimilarity/ZhangUnorderedTreeEditDistanceTest.java
+++ b/src/test/java/org/mastodon/mamut/treesimilarity/ZhangUnorderedTreeEditDistanceTest.java
@@ -29,7 +29,6 @@
 package org.mastodon.mamut.treesimilarity;
 
 import org.apache.commons.lang3.time.StopWatch;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mastodon.mamut.treesimilarity.tree.BranchSpotTreeExamples;
 import org.mastodon.mamut.treesimilarity.tree.DenseSimpleTreeExamples;
@@ -304,7 +303,6 @@ class ZhangUnorderedTreeEditDistanceTest
 	}
 
 	@Test
-	@Disabled( "This test is ignored because it takes too long to run." )
 	void testDenseTreeExample()
 	{
 		Tree< Double > tree2aba = DenseSimpleTreeExamples.tree2aba();

--- a/src/test/java/org/mastodon/mamut/treesimilarity/ZhangUnorderedTreeEditDistanceTest.java
+++ b/src/test/java/org/mastodon/mamut/treesimilarity/ZhangUnorderedTreeEditDistanceTest.java
@@ -39,7 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
-import java.util.function.BiFunction;
+import java.util.function.ToDoubleBiFunction;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -48,7 +48,7 @@ class ZhangUnorderedTreeEditDistanceTest
 {
 	private static final Logger logger = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
 
-	private final static BiFunction< Double, Double, Double > defaultCosts = TreeDistances.LOCAL_ABSOLUTE_COST_FUNCTION;
+	private final static ToDoubleBiFunction< Double, Double > defaultCosts = TreeDistances.LOCAL_ABSOLUTE_COST_FUNCTION;
 
 	@SuppressWarnings("all")
 	@Test
@@ -183,7 +183,7 @@ class ZhangUnorderedTreeEditDistanceTest
 
 
 		// 0, because: the trees are topologically identical
-		BiFunction< Double, Double, Double > costFunction = ( a, b ) -> ( a == null ) == ( b == null ) ? 0d : 1d;
+		ToDoubleBiFunction< Double, Double > costFunction = ( a, b ) -> ( a == null ) == ( b == null ) ? 0d : 1d;
 		assertEquals( 0, ZhangUnorderedTreeEditDistance.distance( simpleTree1, simpleTree2, costFunction ), 0d );
 		assertEquals( 0, ZhangUnorderedTreeEditDistance.distance( simpleTree2, simpleTree1, costFunction ), 0d );
 		assertEquals( 0, ZhangUnorderedTreeEditDistance.distance( branchSpotTree1, branchSpotTree2, costFunction ), 0d );

--- a/src/test/java/org/mastodon/mamut/treesimilarity/ZhangUnorderedTreeEditDistanceTest.java
+++ b/src/test/java/org/mastodon/mamut/treesimilarity/ZhangUnorderedTreeEditDistanceTest.java
@@ -28,13 +28,17 @@
  */
 package org.mastodon.mamut.treesimilarity;
 
+import org.apache.commons.lang3.time.StopWatch;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mastodon.mamut.treesimilarity.tree.BranchSpotTreeExamples;
 import org.mastodon.mamut.treesimilarity.tree.DenseSimpleTreeExamples;
 import org.mastodon.mamut.treesimilarity.tree.SimpleTreeExamples;
 import org.mastodon.mamut.treesimilarity.tree.Tree;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.lang.invoke.MethodHandles;
 import java.util.function.BiFunction;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -42,6 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ZhangUnorderedTreeEditDistanceTest
 {
+	private static final Logger logger = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
 
 	private final static BiFunction< Double, Double, Double > defaultCosts = TreeDistances.LOCAL_ABSOLUTE_COST_FUNCTION;
 
@@ -305,5 +310,17 @@ class ZhangUnorderedTreeEditDistanceTest
 		Tree< Double > tree2aba = DenseSimpleTreeExamples.tree2aba();
 		Tree< Double > tree1bab = DenseSimpleTreeExamples.tree1bab();
 		assertEquals( 39_214d, ZhangUnorderedTreeEditDistance.distance( tree2aba, tree1bab, defaultCosts ), 0d );
+	}
+
+	public static void main( String[] args )
+	{
+		// NB: This exists in addition to testDenseTreeExample(), because time measurement does not work in the test.
+		Tree< Double > tree2aba = DenseSimpleTreeExamples.tree2aba();
+		Tree< Double > tree1bab = DenseSimpleTreeExamples.tree1bab();
+		StopWatch stopWatch = new StopWatch();
+		stopWatch.start();
+		double costs = ZhangUnorderedTreeEditDistance.distance( tree2aba, tree1bab, defaultCosts );
+		stopWatch.stop();
+		logger.debug( "Costs: {}, time: {}ms", costs, stopWatch.getTime() );
 	}
 }

--- a/src/test/java/org/mastodon/mamut/treesimilarity/util/NodeMappingTest.java
+++ b/src/test/java/org/mastodon/mamut/treesimilarity/util/NodeMappingTest.java
@@ -34,7 +34,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.BiFunction;
+import java.util.function.ToDoubleBiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -50,7 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class NodeMappingTest
 {
 
-	private static final BiFunction< Double, Double, Double > DEFAULT_COSTS = ( o1, o2 ) -> {
+	private static final ToDoubleBiFunction< Double, Double > DEFAULT_COSTS = ( o1, o2 ) -> {
 		if ( o2 == null )
 			return o1;
 		else
@@ -165,12 +165,12 @@ class NodeMappingTest
 		double costs = 0;
 		for ( Tree< Double > subtree : TreeUtils.listOfSubtrees( tree1 ) )
 			if ( !keys.contains( subtree ) )
-				costs += DEFAULT_COSTS.apply( subtree.getAttribute(), null );
+				costs += DEFAULT_COSTS.applyAsDouble( subtree.getAttribute(), null );
 		for ( Tree< Double > subtree : TreeUtils.listOfSubtrees( tree2 ) )
 			if ( !values.contains( subtree ) )
-				costs += DEFAULT_COSTS.apply( subtree.getAttribute(), null );
+				costs += DEFAULT_COSTS.applyAsDouble( subtree.getAttribute(), null );
 		for ( Map.Entry< Tree< Double >, Tree< Double > > entry : mapping.entrySet() )
-			costs += DEFAULT_COSTS.apply( entry.getKey().getAttribute(), entry.getValue().getAttribute() );
+			costs += DEFAULT_COSTS.applyAsDouble( entry.getKey().getAttribute(), entry.getValue().getAttribute() );
 		return costs;
 	}
 


### PR DESCRIPTION
Resolves #59 

This PR adds mainly 3 optimizations:
-  Simplification of min cost max flow operation in case of comparing binary trees
  - ~40-60% speed up
- Avoid using Stream API when Add an optimization for the tree edit distance for the case of binary trees
  -  ~25% speed up
- Replace Maps in ZhangUnorderedTreeEditDistance class with Arrays/ArrayLists
  - ~60-70% speed up
- Cache Attribute Value in BranchSpotTree
  - ~20% speed up

In total, this PR gains a speed up of up to ~90%
As Benchmark mainly this demo has been used: https://github.com/mastodon-sc/mastodon-deep-lineage/blob/be8120c8f6ee35cc4f343f4a1b567a0d7679970d/src/test/java/org/mastodon/mamut/treesimilarity/ZhangUnorderedTreeEditDistanceTest.java#L313

or this mastodon file 
[flatSim2_be_2aba_1bab.zip](https://github.com/mastodon-sc/mastodon-deep-lineage/files/15295019/flatSim2_be_2aba_1bab.zip)

with these settings
![grafik](https://github.com/mastodon-sc/mastodon-deep-lineage/assets/10515534/581040f4-12b1-40e8-9af4-5892c6d5b60f)
