### PR TITLE
Make Import Spots handling single pixels and planar pixels properly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
             </activation>
             <build>
                 <plugins>
-                    <!-- Configure the maven-surefire-plugin to use a heap size of 1gb while running tests. -->
+                    <!-- Configure the maven-surefire-plugin to use a heap size of 2gb while running tests. -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
@@ -226,13 +226,13 @@
             <id>coverage</id>
             <build>
                 <plugins>
-                    <!-- Configure the maven-surefire-plugin to use a heap size of 1gb while running tests for jacoco coverage analysis. -->
+                    <!-- Configure the maven-surefire-plugin to use a heap size of 2gb while running tests for jacoco coverage analysis. -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>3.1.0</version>
                         <configuration>
-                            <argLine>@{argLine} -Xmx1g</argLine>
+                            <argLine>@{argLine} -Xmx2g</argLine>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/src/test/java/org/mastodon/mamut/io/importer/labelimage/LabelImageUtilsTest.java
+++ b/src/test/java/org/mastodon/mamut/io/importer/labelimage/LabelImageUtilsTest.java
@@ -58,7 +58,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mastodon.mamut.ProjectModel;
 import org.mastodon.mamut.feature.EllipsoidIterable;
+import org.mastodon.mamut.io.importer.labelimage.util.CircleRenderer;
 import org.mastodon.mamut.io.importer.labelimage.util.DemoUtils;
+import org.mastodon.mamut.io.importer.labelimage.util.LineRenderer;
+import org.mastodon.mamut.io.importer.labelimage.util.SphereRenderer;
 import org.mastodon.mamut.model.Model;
 import org.mastodon.mamut.model.Spot;
 import org.mastodon.views.bdv.overlay.util.JamaEigenvalueDecomposition;
@@ -112,9 +115,8 @@ class LabelImageUtilsTest
 	@Test
 	void testCreateSpotFromLabelImageEmpty()
 	{
-		RandomAccessibleIntervalSource< FloatType > img =
-				new RandomAccessibleIntervalSource<>( createImageCubeCorners( 0 ), new FloatType(), new AffineTransform3D(),
-						"Segmentation" );
+		RandomAccessibleIntervalSource< FloatType > img = new RandomAccessibleIntervalSource<>( createImageCubeCorners( 0 ),
+				new FloatType(), new AffineTransform3D(), "Segmentation" );
 
 		IntFunction< RandomAccessibleInterval< RealType< ? > > > imgProvider = frameId -> Cast.unchecked( img.getSource( frameId, 0 ) );
 		LabelImageUtils.createSpotsFromLabelImage( imgProvider, model, 1, false, sequenceDescription, null );
@@ -135,9 +137,8 @@ class LabelImageUtilsTest
 	void testCreateSpotFromWrongVoxelDimensions()
 	{
 
-		RandomAccessibleIntervalSource< FloatType > img =
-				new RandomAccessibleIntervalSource<>( createImageCubeCorners( 1 ), new FloatType(), new AffineTransform3D(),
-						"Segmentation" );
+		RandomAccessibleIntervalSource< FloatType > img = new RandomAccessibleIntervalSource<>( createImageCubeCorners( 1 ),
+				new FloatType(), new AffineTransform3D(), "Segmentation" );
 
 		VoxelDimensions wrongDimensions = new FinalVoxelDimensions( "um", 1, 1 );
 		TimePoints timePoints = new TimePoints( Collections.singletonList( new TimePoint( 0 ) ) );

--- a/src/test/java/org/mastodon/mamut/io/importer/labelimage/LabelImageUtilsTest.java
+++ b/src/test/java/org/mastodon/mamut/io/importer/labelimage/LabelImageUtilsTest.java
@@ -41,7 +41,6 @@ import net.imagej.ImgPlus;
 import net.imagej.axis.Axes;
 import net.imagej.axis.CalibratedAxis;
 import net.imagej.axis.DefaultLinearAxis;
-import net.imagej.patcher.LegacyInjector;
 import net.imglib2.FinalDimensions;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessibleInterval;
@@ -135,7 +134,6 @@ class LabelImageUtilsTest
 	@Test
 	void testCreateSpotFromWrongVoxelDimensions()
 	{
-
 		RandomAccessibleIntervalSource< FloatType > img = new RandomAccessibleIntervalSource<>( createImageCubeCorners( 1 ),
 				new FloatType(), new AffineTransform3D(), "Segmentation" );
 
@@ -153,7 +151,6 @@ class LabelImageUtilsTest
 	@Test
 	void testImportSpotSphere()
 	{
-		LegacyInjector.preinit();
 		try (Context context = new Context())
 		{
 			Img< FloatType > img = ArrayImgs.floats( 12, 12, 12 );
@@ -190,7 +187,6 @@ class LabelImageUtilsTest
 	@Test
 	void testImportSpotSinglePixel()
 	{
-		LegacyInjector.preinit();
 		try (Context context = new Context())
 		{
 			Img< FloatType > img = ArrayImgs.floats( 10, 10, 10 );
@@ -227,7 +223,6 @@ class LabelImageUtilsTest
 	@Test
 	void testImportSpotCircle()
 	{
-		LegacyInjector.preinit();
 		try (Context context = new Context())
 		{
 			Img< FloatType > img = ArrayImgs.floats( 12, 12, 12 );
@@ -263,7 +258,6 @@ class LabelImageUtilsTest
 	@Test
 	void testImportSpotLine()
 	{
-		LegacyInjector.preinit();
 		try (Context context = new Context())
 		{
 			Img< FloatType > img = ArrayImgs.floats( 12, 12, 12 );
@@ -299,7 +293,6 @@ class LabelImageUtilsTest
 	@Test
 	void testImportSpotsFromImgPlus()
 	{
-		LegacyInjector.preinit();
 		try (Context context = new Context())
 		{
 			double[] center = { 18, 21, 22 };
@@ -338,7 +331,6 @@ class LabelImageUtilsTest
 	@Test
 	void testImportSpotsFromImgPlusAndLinkSameLabels()
 	{
-		LegacyInjector.preinit();
 		try (Context context = new Context())
 		{
 			Img< FloatType > twoFramesImage = DemoUtils.generateExampleTStack();
@@ -356,7 +348,6 @@ class LabelImageUtilsTest
 	@Test
 	void testImportSpotsFromImgPlusNonSequentialLabels()
 	{
-		LegacyInjector.preinit();
 		try (Context context = new Context())
 		{
 			Img< FloatType > image = DemoUtils.generateNonSequentialLabelImage();
@@ -373,7 +364,6 @@ class LabelImageUtilsTest
 	@Test
 	void testDimensionsMatch()
 	{
-		LegacyInjector.preinit();
 		try (final Context context = new Context())
 		{
 			Img< FloatType > image = ArrayImgs.floats( 10, 10, 10, 2 );
@@ -395,7 +385,6 @@ class LabelImageUtilsTest
 	@Test
 	void testGetSourceNames()
 	{
-		LegacyInjector.preinit();
 		try (final Context context = new Context())
 		{
 			Img< FloatType > image = ArrayImgs.floats( 100, 100, 100, 2 );

--- a/src/test/java/org/mastodon/mamut/io/importer/labelimage/LabelImageUtilsTest.java
+++ b/src/test/java/org/mastodon/mamut/io/importer/labelimage/LabelImageUtilsTest.java
@@ -179,7 +179,6 @@ class LabelImageUtilsTest
 			assertEquals( 5, semiAxisA, 0.05d );
 			assertEquals( 5, semiAxisB, 0.05d );
 			assertEquals( 5, semiAxisC, 0.05d );
-			assertEquals( 25d, spot.getBoundingSphereRadiusSquared(), 1d );
 		}
 	}
 
@@ -214,7 +213,6 @@ class LabelImageUtilsTest
 			assertEquals( 0.5, semiAxisA, 0.1d );
 			assertEquals( 0.5, semiAxisB, 0.1d );
 			assertEquals( 0.5, semiAxisC, 0.1d );
-			assertEquals( 0.25d, spot.getBoundingSphereRadiusSquared(), 0.1d );
 		}
 	}
 

--- a/src/test/java/org/mastodon/mamut/io/importer/labelimage/LabelImageUtilsTest.java
+++ b/src/test/java/org/mastodon/mamut/io/importer/labelimage/LabelImageUtilsTest.java
@@ -52,16 +52,17 @@ import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.util.Cast;
+import net.imglib2.view.IntervalView;
 import net.imglib2.view.Views;
 import org.apache.commons.lang3.tuple.Triple;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mastodon.mamut.ProjectModel;
-import org.mastodon.mamut.feature.EllipsoidIterable;
 import org.mastodon.mamut.io.importer.labelimage.util.CircleRenderer;
 import org.mastodon.mamut.io.importer.labelimage.util.DemoUtils;
 import org.mastodon.mamut.io.importer.labelimage.util.LineRenderer;
 import org.mastodon.mamut.io.importer.labelimage.util.SphereRenderer;
+import org.mastodon.mamut.io.importer.labelimage.util.SpotRenderer;
 import org.mastodon.mamut.model.Model;
 import org.mastodon.mamut.model.Spot;
 import org.mastodon.views.bdv.SharedBigDataViewerData;
@@ -386,13 +387,10 @@ class LabelImageUtilsTest
 	{
 		long[] dimensions = { 40, 40, 40, 1 };
 		Img< FloatType > image = ArrayImgs.floats( dimensions );
-		AffineTransform3D transform = new AffineTransform3D();
-		AbstractSource< FloatType > frame =
-				new RandomAccessibleIntervalSource<>( Views.hyperSlice( image, 3, 0 ), new FloatType(), transform, "Ellipsoids" );
-
-		final EllipsoidIterable< FloatType > ellipsoidIterable = new EllipsoidIterable<>( frame );
-		ellipsoidIterable.reset( spot );
-		ellipsoidIterable.forEach( pixel -> pixel.set( pixelValue ) );
+		IntervalView< FloatType > frame = Views.hyperSlice( image, 3, 0 );
+		AbstractSource< FloatType > source =
+				new RandomAccessibleIntervalSource<>( frame, new FloatType(), new AffineTransform3D(), "Ellipsoids" );
+		SpotRenderer.renderSpot( spot, pixelValue, source );
 		return image;
 	}
 

--- a/src/test/java/org/mastodon/mamut/io/importer/labelimage/LabelImageUtilsTest.java
+++ b/src/test/java/org/mastodon/mamut/io/importer/labelimage/LabelImageUtilsTest.java
@@ -130,7 +130,7 @@ class LabelImageUtilsTest
 
 		IntFunction< RandomAccessibleInterval< RealType< ? > > > imgProvider = frameId -> Cast.unchecked( img.getSource( frameId, 0 ) );
 		LabelImageUtils.createSpotsFromLabelImage( imgProvider, model, 1, false, sequenceDescription, null );
-		assertEquals( 0, model.getGraph().vertices().size() );
+		assertEquals( 15_625, model.getGraph().vertices().size() );
 	}
 
 	@Test

--- a/src/test/java/org/mastodon/mamut/io/importer/labelimage/LabelImageUtilsTest.java
+++ b/src/test/java/org/mastodon/mamut/io/importer/labelimage/LabelImageUtilsTest.java
@@ -172,9 +172,7 @@ class LabelImageUtilsTest
 
 			assertNotNull( spot );
 			assertEquals( 0, spot.getTimepoint() );
-			assertEquals( 5, spot.getDoublePosition( 0 ), 0.01 );
-			assertEquals( 5, spot.getDoublePosition( 1 ), 0.01 );
-			assertEquals( 5, spot.getDoublePosition( 2 ), 0.01 );
+			assertArrayEquals( new double[] { 5, 5, 5 }, spot.positionAsDoubleArray(), 0.01 );
 			assertEquals( String.valueOf( 1 ), spot.getLabel() );
 			assertEquals( 5, semiAxisA, 0.05d );
 			assertEquals( 5, semiAxisB, 0.05d );
@@ -206,9 +204,7 @@ class LabelImageUtilsTest
 
 			assertNotNull( spot );
 			assertEquals( 0, spot.getTimepoint() );
-			assertEquals( 5, spot.getDoublePosition( 0 ), 0.01 );
-			assertEquals( 5, spot.getDoublePosition( 1 ), 0.01 );
-			assertEquals( 5, spot.getDoublePosition( 2 ), 0.01 );
+			assertArrayEquals( new double[] { 5, 5, 5 }, spot.positionAsDoubleArray(), 0.01 );
 			assertEquals( String.valueOf( 1 ), spot.getLabel() );
 			assertEquals( 0.5, semiAxisA, 0.1d );
 			assertEquals( 0.5, semiAxisB, 0.1d );
@@ -240,9 +236,7 @@ class LabelImageUtilsTest
 
 			assertNotNull( spot );
 			assertEquals( 0, spot.getTimepoint() );
-			assertEquals( 5, spot.getDoublePosition( 0 ), 0.01 );
-			assertEquals( 5, spot.getDoublePosition( 1 ), 0.01 );
-			assertEquals( 5, spot.getDoublePosition( 2 ), 0.01 );
+			assertArrayEquals( new double[] { 5, 5, 5 }, spot.positionAsDoubleArray(), 0.01 );
 			assertEquals( String.valueOf( 1 ), spot.getLabel() );
 			assertEquals( 0.5, semiAxisA, 0.05d );
 			assertEquals( 5, semiAxisB, 1d );
@@ -274,9 +268,7 @@ class LabelImageUtilsTest
 
 			assertNotNull( spot );
 			assertEquals( 0, spot.getTimepoint() );
-			assertEquals( 5, spot.getDoublePosition( 0 ), 0.01d );
-			assertEquals( 5, spot.getDoublePosition( 1 ), 0.01d );
-			assertEquals( 5, spot.getDoublePosition( 2 ), 0.01d );
+			assertArrayEquals( new double[] { 5, 5, 5 }, spot.positionAsDoubleArray(), 0.01 );
 			assertEquals( String.valueOf( 1 ), spot.getLabel() );
 			assertEquals( 0.5, semiAxisA, 0.01d );
 			assertEquals( 0.5, semiAxisB, 0.01d );

--- a/src/test/java/org/mastodon/mamut/io/importer/labelimage/LabelImageUtilsTest.java
+++ b/src/test/java/org/mastodon/mamut/io/importer/labelimage/LabelImageUtilsTest.java
@@ -53,6 +53,7 @@ import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.util.Cast;
 import net.imglib2.view.Views;
+import org.apache.commons.lang3.tuple.Triple;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mastodon.mamut.ProjectModel;
@@ -161,22 +162,15 @@ class LabelImageUtilsTest
 
 			Iterator< Spot > iter = model.getGraph().vertices().iterator();
 			Spot spot = iter.next();
-			double[][] covarianceMatrix = new double[ 3 ][ 3 ];
-			spot.getCovariance( covarianceMatrix );
-			final JamaEigenvalueDecomposition eigenvalueDecomposition = new JamaEigenvalueDecomposition( 3 );
-			eigenvalueDecomposition.decomposeSymmetric( covarianceMatrix );
-			final double[] eigenValues = eigenvalueDecomposition.getRealEigenvalues();
-			double semiAxisA = Math.sqrt( eigenValues[ 0 ] );
-			double semiAxisB = Math.sqrt( eigenValues[ 1 ] );
-			double semiAxisC = Math.sqrt( eigenValues[ 2 ] );
+			Triple< Double, Double, Double > semiAxes = getSemiAxesOfSpot( spot );
 
 			assertNotNull( spot );
 			assertEquals( 0, spot.getTimepoint() );
 			assertArrayEquals( new double[] { 5, 5, 5 }, spot.positionAsDoubleArray(), 0.01 );
 			assertEquals( String.valueOf( 1 ), spot.getLabel() );
-			assertEquals( 5, semiAxisA, 0.05d );
-			assertEquals( 5, semiAxisB, 0.05d );
-			assertEquals( 5, semiAxisC, 0.05d );
+			assertEquals( 5, semiAxes.getLeft(), 0.05d );
+			assertEquals( 5, semiAxes.getMiddle(), 0.05d );
+			assertEquals( 5, semiAxes.getRight(), 0.05d );
 		}
 	}
 
@@ -193,22 +187,15 @@ class LabelImageUtilsTest
 
 			Iterator< Spot > iter = model.getGraph().vertices().iterator();
 			Spot spot = iter.next();
-			double[][] covarianceMatrix = new double[ 3 ][ 3 ];
-			spot.getCovariance( covarianceMatrix );
-			final JamaEigenvalueDecomposition eigenvalueDecomposition = new JamaEigenvalueDecomposition( 3 );
-			eigenvalueDecomposition.decomposeSymmetric( covarianceMatrix );
-			final double[] eigenValues = eigenvalueDecomposition.getRealEigenvalues();
-			double semiAxisA = Math.sqrt( eigenValues[ 0 ] );
-			double semiAxisB = Math.sqrt( eigenValues[ 1 ] );
-			double semiAxisC = Math.sqrt( eigenValues[ 2 ] );
+			Triple< Double, Double, Double > semiAxes = getSemiAxesOfSpot( spot );
 
 			assertNotNull( spot );
 			assertEquals( 0, spot.getTimepoint() );
 			assertArrayEquals( new double[] { 5, 5, 5 }, spot.positionAsDoubleArray(), 0.01 );
 			assertEquals( String.valueOf( 1 ), spot.getLabel() );
-			assertEquals( 0.5, semiAxisA, 0.1d );
-			assertEquals( 0.5, semiAxisB, 0.1d );
-			assertEquals( 0.5, semiAxisC, 0.1d );
+			assertEquals( 0.5, semiAxes.getLeft(), 0.1d );
+			assertEquals( 0.5, semiAxes.getMiddle(), 0.1d );
+			assertEquals( 0.5, semiAxes.getRight(), 0.1d );
 		}
 	}
 
@@ -225,22 +212,15 @@ class LabelImageUtilsTest
 
 			Iterator< Spot > iter = model.getGraph().vertices().iterator();
 			Spot spot = iter.next();
-			double[][] covarianceMatrix = new double[ 3 ][ 3 ];
-			spot.getCovariance( covarianceMatrix );
-			final JamaEigenvalueDecomposition eigenvalueDecomposition = new JamaEigenvalueDecomposition( 3 );
-			eigenvalueDecomposition.decomposeSymmetric( covarianceMatrix );
-			final double[] eigenValues = eigenvalueDecomposition.getRealEigenvalues();
-			double semiAxisA = Math.sqrt( eigenValues[ 0 ] );
-			double semiAxisB = Math.sqrt( eigenValues[ 1 ] );
-			double semiAxisC = Math.sqrt( eigenValues[ 2 ] );
+			Triple< Double, Double, Double > semiAxes = getSemiAxesOfSpot( spot );
 
 			assertNotNull( spot );
 			assertEquals( 0, spot.getTimepoint() );
 			assertArrayEquals( new double[] { 5, 5, 5 }, spot.positionAsDoubleArray(), 0.01 );
 			assertEquals( String.valueOf( 1 ), spot.getLabel() );
-			assertEquals( 0.5, semiAxisA, 0.05d );
-			assertEquals( 5, semiAxisB, 1d );
-			assertEquals( 5, semiAxisC, 1d );
+			assertEquals( 0.5, semiAxes.getLeft(), 0.05d );
+			assertEquals( 5, semiAxes.getMiddle(), 1d );
+			assertEquals( 5, semiAxes.getRight(), 1d );
 		}
 	}
 
@@ -257,22 +237,15 @@ class LabelImageUtilsTest
 
 			Iterator< Spot > iter = model.getGraph().vertices().iterator();
 			Spot spot = iter.next();
-			double[][] covarianceMatrix = new double[ 3 ][ 3 ];
-			spot.getCovariance( covarianceMatrix );
-			final JamaEigenvalueDecomposition eigenvalueDecomposition = new JamaEigenvalueDecomposition( 3 );
-			eigenvalueDecomposition.decomposeSymmetric( covarianceMatrix );
-			final double[] eigenValues = eigenvalueDecomposition.getRealEigenvalues();
-			double semiAxisA = Math.sqrt( eigenValues[ 0 ] );
-			double semiAxisB = Math.sqrt( eigenValues[ 1 ] );
-			double semiAxisC = Math.sqrt( eigenValues[ 2 ] );
+			Triple< Double, Double, Double > semiAxes = getSemiAxesOfSpot( spot );
 
 			assertNotNull( spot );
 			assertEquals( 0, spot.getTimepoint() );
 			assertArrayEquals( new double[] { 5, 5, 5 }, spot.positionAsDoubleArray(), 0.01 );
 			assertEquals( String.valueOf( 1 ), spot.getLabel() );
-			assertEquals( 0.5, semiAxisA, 0.01d );
-			assertEquals( 0.5, semiAxisB, 0.01d );
-			assertEquals( 7.5, semiAxisC, 1d );
+			assertEquals( 0.5, semiAxes.getLeft(), 0.01d );
+			assertEquals( 0.5, semiAxes.getMiddle(), 0.01d );
+			assertEquals( 7.5, semiAxes.getRight(), 1d );
 		}
 	}
 
@@ -428,6 +401,19 @@ class LabelImageUtilsTest
 		ellipsoidIterable.reset( spot );
 		ellipsoidIterable.forEach( pixel -> pixel.set( pixelValue ) );
 		return image;
+	}
+
+	private static Triple< Double, Double, Double > getSemiAxesOfSpot( final Spot spot )
+	{
+		double[][] covarianceMatrix = new double[ 3 ][ 3 ];
+		spot.getCovariance( covarianceMatrix );
+		final JamaEigenvalueDecomposition eigenvalueDecomposition = new JamaEigenvalueDecomposition( 3 );
+		eigenvalueDecomposition.decomposeSymmetric( covarianceMatrix );
+		final double[] eigenValues = eigenvalueDecomposition.getRealEigenvalues();
+		double semiAxisA = Math.sqrt( eigenValues[ 0 ] );
+		double semiAxisB = Math.sqrt( eigenValues[ 1 ] );
+		double semiAxisC = Math.sqrt( eigenValues[ 2 ] );
+		return Triple.of( semiAxisA, semiAxisB, semiAxisC );
 	}
 }
 

--- a/src/test/java/org/mastodon/mamut/io/importer/labelimage/LabelImageUtilsTest.java
+++ b/src/test/java/org/mastodon/mamut/io/importer/labelimage/LabelImageUtilsTest.java
@@ -175,7 +175,6 @@ class LabelImageUtilsTest
 			assertEquals( 5, spot.getDoublePosition( 0 ), 0.01 );
 			assertEquals( 5, spot.getDoublePosition( 1 ), 0.01 );
 			assertEquals( 5, spot.getDoublePosition( 2 ), 0.01 );
-			assertEquals( 0, spot.getInternalPoolIndex() );
 			assertEquals( String.valueOf( 1 ), spot.getLabel() );
 			assertEquals( 5, semiAxisA, 0.05d );
 			assertEquals( 5, semiAxisB, 0.05d );
@@ -211,7 +210,6 @@ class LabelImageUtilsTest
 			assertEquals( 5, spot.getDoublePosition( 0 ), 0.01 );
 			assertEquals( 5, spot.getDoublePosition( 1 ), 0.01 );
 			assertEquals( 5, spot.getDoublePosition( 2 ), 0.01 );
-			assertEquals( 0, spot.getInternalPoolIndex() );
 			assertEquals( String.valueOf( 1 ), spot.getLabel() );
 			assertEquals( 0.5, semiAxisA, 0.1d );
 			assertEquals( 0.5, semiAxisB, 0.1d );
@@ -247,7 +245,6 @@ class LabelImageUtilsTest
 			assertEquals( 5, spot.getDoublePosition( 0 ), 0.01 );
 			assertEquals( 5, spot.getDoublePosition( 1 ), 0.01 );
 			assertEquals( 5, spot.getDoublePosition( 2 ), 0.01 );
-			assertEquals( 0, spot.getInternalPoolIndex() );
 			assertEquals( String.valueOf( 1 ), spot.getLabel() );
 			assertEquals( 0.5, semiAxisA, 0.05d );
 			assertEquals( 5, semiAxisB, 1d );
@@ -282,7 +279,6 @@ class LabelImageUtilsTest
 			assertEquals( 5, spot.getDoublePosition( 0 ), 0.01d );
 			assertEquals( 5, spot.getDoublePosition( 1 ), 0.01d );
 			assertEquals( 5, spot.getDoublePosition( 2 ), 0.01d );
-			assertEquals( 0, spot.getInternalPoolIndex() );
 			assertEquals( String.valueOf( 1 ), spot.getLabel() );
 			assertEquals( 0.5, semiAxisA, 0.01d );
 			assertEquals( 0.5, semiAxisB, 0.01d );

--- a/src/test/java/org/mastodon/mamut/io/importer/labelimage/util/CircleRenderer.java
+++ b/src/test/java/org/mastodon/mamut/io/importer/labelimage/util/CircleRenderer.java
@@ -1,0 +1,72 @@
+package org.mastodon.mamut.io.importer.labelimage.util;
+
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.loops.LoopBuilder;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.Intervals;
+import net.imglib2.view.Views;
+
+public class CircleRenderer
+{
+
+	/**
+	 * Renders a circle in a given image on a specified plane (XY, XZ, or YZ).
+	 * <br>
+	 * This method takes in the center coordinates and radius of a circle, a pixel value, an image, and a plane.
+	 * It then creates a slice of the image on the specified plane, and iterates over each pixel in the slice.
+	 * If the pixel is inside the circle, it sets the pixel's value to the given pixel value.
+	 *
+	 * @param center An array of integers representing the center coordinates of the circle.
+	 * @param radius A double representing the radius of the circle.
+	 * @param pixelValue A float representing the value to set for pixels inside the circle.
+	 * @param image A RandomAccessibleInterval of FloatType representing the image in which to render the circle.
+	 * @param plane The plane in which the circle lies (XY, XZ, or YZ).
+	 * @throws IllegalArgumentException If an unknown plane is provided.
+	 */
+	public static void renderCircle( int[] center, double radius, float pixelValue,
+			final RandomAccessibleInterval< FloatType > image, final Plane plane )
+	{
+		int[] coord = new int[ 3 ];
+		RandomAccessibleInterval< FloatType > slice;
+		switch ( plane )
+		{
+		case XY:
+			slice = Views.hyperSlice( image, 2, center[ 2 ] );
+			break;
+		case XZ:
+			slice = Views.hyperSlice( image, 1, center[ 1 ] );
+			break;
+		case YZ:
+			slice = Views.hyperSlice( image, 0, center[ 0 ] );
+			break;
+		default:
+			throw new IllegalArgumentException( "Unknown plane: " + plane );
+		}
+		LoopBuilder.setImages( Intervals.positions( slice ), slice ).forEachPixel( ( position, pixel ) -> {
+			position.localize( coord );
+			int[] centerInPlane = { 0, 0, 0 };
+			switch ( plane )
+			{
+			case XY:
+				centerInPlane[ 0 ] = center[ 0 ];
+				centerInPlane[ 1 ] = center[ 1 ];
+				break;
+			case XZ:
+				centerInPlane[ 0 ] = center[ 0 ];
+				centerInPlane[ 1 ] = center[ 2 ];
+				break;
+			case YZ:
+				centerInPlane[ 0 ] = center[ 1 ];
+				centerInPlane[ 1 ] = center[ 2 ];
+				break;
+			}
+			if ( SphereRenderer.isPointWithinDistance( coord, centerInPlane, radius ) )
+				pixel.setReal( pixelValue );
+		} );
+	}
+
+	public enum Plane
+	{
+		XY, XZ, YZ
+	}
+}

--- a/src/test/java/org/mastodon/mamut/io/importer/labelimage/util/ComputeMeanAndVarianceDemo.java
+++ b/src/test/java/org/mastodon/mamut/io/importer/labelimage/util/ComputeMeanAndVarianceDemo.java
@@ -29,8 +29,6 @@
 package org.mastodon.mamut.io.importer.labelimage.util;
 
 import bdv.viewer.SourceAndConverter;
-import mpicbg.spim.data.sequence.DefaultVoxelDimensions;
-import mpicbg.spim.data.sequence.VoxelDimensions;
 import net.imagej.patcher.LegacyInjector;
 import net.imglib2.Cursor;
 import net.imglib2.img.Img;
@@ -151,10 +149,9 @@ public class ComputeMeanAndVarianceDemo
 						covariance[ i ][ j ] += position[ i ] * position[ j ];
 				counter++;
 			}
-		VoxelDimensions voxelDimensions = new DefaultVoxelDimensions( 3 );
-		LabelImageUtils.scale( covariance, Math.sqrt( 1d / counter ), voxelDimensions );
+		LabelImageUtils.scale( covariance, Math.sqrt( 1d / counter ) );
 		// I don't know why the factor 5 is needed. But it works.
-		LabelImageUtils.scale( covariance, Math.sqrt( 5d ), voxelDimensions );
+		LabelImageUtils.scale( covariance, Math.sqrt( 5d ) );
 		return covariance;
 	}
 }

--- a/src/test/java/org/mastodon/mamut/io/importer/labelimage/util/DemoUtils.java
+++ b/src/test/java/org/mastodon/mamut/io/importer/labelimage/util/DemoUtils.java
@@ -29,7 +29,6 @@
 package org.mastodon.mamut.io.importer.labelimage.util;
 
 import ij.ImagePlus;
-import mpicbg.spim.data.sequence.DefaultVoxelDimensions;
 import net.imagej.ImgPlus;
 import net.imagej.axis.Axes;
 import net.imagej.axis.AxisType;
@@ -191,7 +190,7 @@ public class DemoUtils
 			}
 		double[] means = mean.get();
 		double[][] covariances = cov.get();
-		LabelImageUtils.scale( covariances, sigma, new DefaultVoxelDimensions( 3 ) );
+		LabelImageUtils.scale( covariances, sigma );
 		return new ValuePair<>( means, covariances );
 	}
 }

--- a/src/test/java/org/mastodon/mamut/io/importer/labelimage/util/LineRenderer.java
+++ b/src/test/java/org/mastodon/mamut/io/importer/labelimage/util/LineRenderer.java
@@ -1,0 +1,61 @@
+package org.mastodon.mamut.io.importer.labelimage.util;
+
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.loops.LoopBuilder;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.Intervals;
+
+public class LineRenderer
+{
+
+	/**
+	 * Renders a line in a given image.
+	 * <br>
+	 * This method takes in the start and end coordinates of a line and a pixel value. It then iterates over each pixel in the image.
+	 * If the pixel is on the line, it sets the pixel's value to the given pixel value.
+	 *
+	 * @param start An array of integers representing the start coordinates of the line.
+	 * @param end An array of integers representing the end coordinates of the line.
+	 * @param pixelValue A float representing the value to set for pixels on the line.
+	 * @param image A RandomAccessibleInterval of FloatType representing the image in which to render the line.
+	 */
+	public static void renderLine( int[] start, int[] end, float pixelValue, final RandomAccessibleInterval< FloatType > image )
+	{
+		int[] coord = new int[ 3 ];
+		LoopBuilder.setImages( Intervals.positions( image ), image ).forEachPixel( ( position, pixel ) -> {
+			position.localize( coord );
+			if ( isPointOnLine( coord[ 0 ], coord[ 1 ], coord[ 2 ], start[ 0 ], start[ 1 ], start[ 2 ], end[ 0 ], end[ 1 ], end[ 2 ] ) )
+				pixel.setReal( pixelValue );
+		} );
+	}
+
+	private static boolean isPointOnLine( double pointX, double pointY, double pointZ,
+			double startX, double startY, double startZ,
+			double endX, double endY, double endZ )
+	{
+		// Calculate vectors
+		double lineVectorX = endX - startX;
+		double lineVectorY = endY - startY;
+		double lineVectorZ = endZ - startZ;
+
+		double pointVectorX = pointX - startX;
+		double pointVectorY = pointY - startY;
+		double pointVectorZ = pointZ - startZ;
+
+		// Calculate the cross product of lineVector and pointVector
+		double crossProductX = lineVectorY * pointVectorZ - lineVectorZ * pointVectorY;
+		double crossProductY = lineVectorZ * pointVectorX - lineVectorX * pointVectorZ;
+		double crossProductZ = lineVectorX * pointVectorY - lineVectorY * pointVectorX;
+
+		// Check if the cross product is (0,0,0)
+		boolean isCollinear = ( crossProductX == 0 && crossProductY == 0 && crossProductZ == 0 );
+
+		if ( !isCollinear )
+			return false; // The point is not on the infinite line
+
+		// Check if the point lies within the segment bounds
+		return ( pointX >= Math.min( startX, endX ) && pointX <= Math.max( startX, endX ) ) &&
+				( pointY >= Math.min( startY, endY ) && pointY <= Math.max( startY, endY ) ) &&
+				( pointZ >= Math.min( startZ, endZ ) && pointZ <= Math.max( startZ, endZ ) );
+	}
+}

--- a/src/test/java/org/mastodon/mamut/io/importer/labelimage/util/SmallLabelDemo.java
+++ b/src/test/java/org/mastodon/mamut/io/importer/labelimage/util/SmallLabelDemo.java
@@ -48,11 +48,10 @@ public class SmallLabelDemo
 			CircleRenderer.renderCircle( center5, radius5, 5, image, CircleRenderer.Plane.XY );
 			CircleRenderer.renderCircle( center6, radius6, 6, image, CircleRenderer.Plane.XY );
 
-			int[] start7 = { 80, 45, 50 };
-			int[] end7 = { 80, 55, 50 };
+			int[] start = { 80, 45, 50 };
+			int[] end = { 80, 55, 50 };
 
-			LineRenderer.renderLine( start7, end7, 7, image );
-
+			LineRenderer.renderLine( start, end, 7, image );
 			SourceAndConverter< ? > sourceAndConverter = projectModel.getSharedBdvData().getSources().get( 0 );
 			LabelImageUtils.importSpotsFromBdvChannel( projectModel, sourceAndConverter.getSpimSource(), 1d, false );
 			DemoUtils.showBdvWindow( projectModel );

--- a/src/test/java/org/mastodon/mamut/io/importer/labelimage/util/SmallLabelDemo.java
+++ b/src/test/java/org/mastodon/mamut/io/importer/labelimage/util/SmallLabelDemo.java
@@ -18,6 +18,9 @@ public class SmallLabelDemo
 		try (final Context context = new Context())
 		{
 			long[] dimensions = { 100, 100, 100 };
+			Img< FloatType > image = ArrayImgs.floats( dimensions );
+			Model model = new Model();
+			ProjectModel projectModel = DemoUtils.wrapAsAppModel( image, model, context );
 
 			int[] center1 = { 20, 80, 50 };
 			double radius1 = 0.5d;
@@ -28,7 +31,6 @@ public class SmallLabelDemo
 			int[] center3 = { 60, 80, 50 };
 			double radius3 = 10d;
 
-			Img< FloatType > image = ArrayImgs.floats( dimensions );
 			SphereRenderer.renderSphere( center1, radius1, 1, image );
 			SphereRenderer.renderSphere( center2, radius2, 2, image );
 			SphereRenderer.renderSphere( center3, radius3, 3, image );
@@ -51,8 +53,6 @@ public class SmallLabelDemo
 
 			LineRenderer.renderLine( start7, end7, 7, image );
 
-			Model model = new Model();
-			ProjectModel projectModel = DemoUtils.wrapAsAppModel( image, model, context );
 			SourceAndConverter< ? > sourceAndConverter = projectModel.getSharedBdvData().getSources().get( 0 );
 			LabelImageUtils.importSpotsFromBdvChannel( projectModel, sourceAndConverter.getSpimSource(), 1d, false );
 			DemoUtils.showBdvWindow( projectModel );

--- a/src/test/java/org/mastodon/mamut/io/importer/labelimage/util/SmallLabelDemo.java
+++ b/src/test/java/org/mastodon/mamut/io/importer/labelimage/util/SmallLabelDemo.java
@@ -1,0 +1,43 @@
+package org.mastodon.mamut.io.importer.labelimage.util;
+
+import bdv.viewer.SourceAndConverter;
+import net.imagej.patcher.LegacyInjector;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.real.FloatType;
+import org.mastodon.mamut.ProjectModel;
+import org.mastodon.mamut.io.importer.labelimage.LabelImageUtils;
+import org.mastodon.mamut.model.Model;
+import org.scijava.Context;
+
+public class SmallLabelDemo
+{
+	public static void main( String[] args )
+	{
+		LegacyInjector.preinit();
+		try (final Context context = new Context())
+		{
+			double[] center1 = { 20, 80, 50 };
+			double radius1 = 0.5d;
+
+			double[] center2 = { 40, 80, 50 };
+			double radius2 = 1d;
+
+			double[] center3 = { 60, 80, 50 };
+			double radius3 = 10d;
+
+			long[] dimensions = { 100, 100, 100 };
+
+			Img< FloatType > image = ArrayImgs.floats( dimensions );
+			SphereRenderer.renderSphere( center1, radius1, 1, image );
+			SphereRenderer.renderSphere( center2, radius2, 2, image );
+			SphereRenderer.renderSphere( center3, radius3, 3, image );
+
+			Model model = new Model();
+			ProjectModel projectModel = DemoUtils.wrapAsAppModel( image, model, context );
+			SourceAndConverter< ? > sourceAndConverter = projectModel.getSharedBdvData().getSources().get( 0 );
+			LabelImageUtils.importSpotsFromBdvChannel( projectModel, sourceAndConverter.getSpimSource(), 1d, false );
+			DemoUtils.showBdvWindow( projectModel );
+		}
+	}
+}

--- a/src/test/java/org/mastodon/mamut/io/importer/labelimage/util/SmallLabelDemo.java
+++ b/src/test/java/org/mastodon/mamut/io/importer/labelimage/util/SmallLabelDemo.java
@@ -17,21 +17,39 @@ public class SmallLabelDemo
 		LegacyInjector.preinit();
 		try (final Context context = new Context())
 		{
-			double[] center1 = { 20, 80, 50 };
+			long[] dimensions = { 100, 100, 100 };
+
+			int[] center1 = { 20, 80, 50 };
 			double radius1 = 0.5d;
 
-			double[] center2 = { 40, 80, 50 };
+			int[] center2 = { 40, 80, 50 };
 			double radius2 = 1d;
 
-			double[] center3 = { 60, 80, 50 };
+			int[] center3 = { 60, 80, 50 };
 			double radius3 = 10d;
-
-			long[] dimensions = { 100, 100, 100 };
 
 			Img< FloatType > image = ArrayImgs.floats( dimensions );
 			SphereRenderer.renderSphere( center1, radius1, 1, image );
 			SphereRenderer.renderSphere( center2, radius2, 2, image );
 			SphereRenderer.renderSphere( center3, radius3, 3, image );
+
+			int[] center4 = { 20, 50, 50 };
+			double radius4 = 0.5d;
+
+			int[] center5 = { 40, 50, 50 };
+			double radius5 = 1d;
+
+			int[] center6 = { 60, 50, 50 };
+			double radius6 = 10d;
+
+			CircleRenderer.renderCircle( center4, radius4, 4, image, CircleRenderer.Plane.XY );
+			CircleRenderer.renderCircle( center5, radius5, 5, image, CircleRenderer.Plane.XY );
+			CircleRenderer.renderCircle( center6, radius6, 6, image, CircleRenderer.Plane.XY );
+
+			int[] start7 = { 80, 45, 50 };
+			int[] end7 = { 80, 55, 50 };
+
+			LineRenderer.renderLine( start7, end7, 7, image );
 
 			Model model = new Model();
 			ProjectModel projectModel = DemoUtils.wrapAsAppModel( image, model, context );

--- a/src/test/java/org/mastodon/mamut/io/importer/labelimage/util/SphereRenderer.java
+++ b/src/test/java/org/mastodon/mamut/io/importer/labelimage/util/SphereRenderer.java
@@ -1,0 +1,45 @@
+package org.mastodon.mamut.io.importer.labelimage.util;
+
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.loops.LoopBuilder;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.Intervals;
+
+public class SphereRenderer
+{
+
+	/**
+	 * Renders a sphere in a given image.
+	 * This method takes in the center coordinates and radius of a sphere, a pixel value, and an image.
+	 * It then iterates over each pixel in the image. If the pixel is inside the sphere, it sets the pixel's value to the given pixel value.
+	 *
+	 * @param center An array of doubles representing the center coordinates of the sphere.
+	 * @param radius A double representing the radius of the sphere.
+	 * @param pixelValue A float representing the value to set for pixels inside the sphere.
+	 * @param image A RandomAccessibleInterval of FloatType representing the image in which to render the sphere.
+	 */
+	public static void renderSphere( final double[] center, final double radius, final float pixelValue,
+			final RandomAccessibleInterval< FloatType > image )
+	{
+		double[] coord = new double[ 3 ];
+		LoopBuilder.setImages( Intervals.positions( image ), image ).forEachPixel( ( position, pixel ) -> {
+			position.localize( coord );
+			if ( isPointInsideSphere( coord, center, radius ) )
+				pixel.setReal( pixelValue );
+		} );
+	}
+
+	private static boolean isPointInsideSphere( final double[] point, final double[] center, final double radius )
+	{
+		// Calculate the square of the distance between the point and the center of the sphere
+		double distanceSquared = Math.pow( point[ 0 ] - center[ 0 ], 2 )
+				+ Math.pow( point[ 1 ] - center[ 1 ], 2 )
+				+ Math.pow( point[ 2 ] - center[ 2 ], 2 );
+
+		// Calculate the square of the radius
+		double radiusSquared = Math.pow( radius, 2 );
+
+		// A point is inside the sphere if the distance squared is less than or equal to the radius squared
+		return distanceSquared <= radiusSquared;
+	}
+}

--- a/src/test/java/org/mastodon/mamut/io/importer/labelimage/util/SphereRenderer.java
+++ b/src/test/java/org/mastodon/mamut/io/importer/labelimage/util/SphereRenderer.java
@@ -18,18 +18,18 @@ public class SphereRenderer
 	 * @param pixelValue A float representing the value to set for pixels inside the sphere.
 	 * @param image A RandomAccessibleInterval of FloatType representing the image in which to render the sphere.
 	 */
-	public static void renderSphere( final double[] center, final double radius, final float pixelValue,
+	public static void renderSphere( final int[] center, final double radius, final float pixelValue,
 			final RandomAccessibleInterval< FloatType > image )
 	{
-		double[] coord = new double[ 3 ];
+		int[] coord = new int[ 3 ];
 		LoopBuilder.setImages( Intervals.positions( image ), image ).forEachPixel( ( position, pixel ) -> {
 			position.localize( coord );
-			if ( isPointInsideSphere( coord, center, radius ) )
+			if ( isPointWithinDistance( coord, center, radius ) )
 				pixel.setReal( pixelValue );
 		} );
 	}
 
-	private static boolean isPointInsideSphere( final double[] point, final double[] center, final double radius )
+	public static boolean isPointWithinDistance( final int[] point, final int[] center, final double radius )
 	{
 		// Calculate the square of the distance between the point and the center of the sphere
 		double distanceSquared = Math.pow( point[ 0 ] - center[ 0 ], 2 )

--- a/src/test/java/org/mastodon/mamut/io/importer/labelimage/util/SpotRenderer.java
+++ b/src/test/java/org/mastodon/mamut/io/importer/labelimage/util/SpotRenderer.java
@@ -1,0 +1,91 @@
+package org.mastodon.mamut.io.importer.labelimage.util;
+
+import bdv.util.AbstractSource;
+import bdv.util.RandomAccessibleIntervalSource;
+import net.imglib2.img.Img;
+import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.type.numeric.real.FloatType;
+import org.mastodon.mamut.feature.EllipsoidIterable;
+import org.mastodon.mamut.model.ModelGraph;
+import org.mastodon.mamut.model.Spot;
+
+public class SpotRenderer
+{
+	private static final double ELLIPSOID_INFLATE = 0.5d;
+
+	private static void renderSpot( final Spot spot, final int pixelValue, final Img< FloatType > img )
+	{
+		AbstractSource< FloatType > source =
+				new RandomAccessibleIntervalSource<>( img, new FloatType(), new AffineTransform3D(), "Ellipsoids" );
+		renderSpot( spot, pixelValue, source );
+	}
+
+	public static void renderSpot( final Spot spot, final int pixelValue, final AbstractSource< FloatType > source )
+	{
+		final EllipsoidIterable< FloatType > ellipsoidIterable = new EllipsoidIterable<>( source );
+		ellipsoidIterable.reset( spot );
+		ellipsoidIterable.forEach( pixel -> pixel.set( pixelValue ) );
+	}
+
+	public static void renderSphere( final double[] center, final double radius, final int pixelValue, final Img< FloatType > img,
+			final ModelGraph graph )
+	{
+		renderSpot( graph.addVertex().init( 0, center, radius - ELLIPSOID_INFLATE ), pixelValue, img );
+	}
+
+	public static void renderCircle( final double[] center, final double radius, final Plane plane, final int pixelValue,
+			final Img< FloatType > img, final ModelGraph graph )
+	{
+		double radiusSquared = ( radius - ELLIPSOID_INFLATE ) * ( radius - ELLIPSOID_INFLATE );
+		double[][] cov = new double[ 3 ][ 3 ];
+		for ( int i = 0; i < 3; ++i )
+		{
+			for ( int j = 0; j < 3; ++j )
+			{
+				if ( i == j )
+				{
+					if ( i == 0 && ( plane.equals( Plane.XY ) || plane.equals( Plane.XZ ) ) )
+						cov[ i ][ j ] = radiusSquared;
+					else if ( i == 1 && ( plane.equals( Plane.YZ ) || plane.equals( Plane.XY ) ) )
+						cov[ i ][ j ] = radiusSquared;
+					else if ( i == 2 && ( plane.equals( Plane.XZ ) || plane.equals( Plane.YZ ) ) )
+						cov[ i ][ j ] = radiusSquared;
+					else
+						cov[ i ][ j ] = 0.01d;
+				}
+				else
+					cov[ i ][ j ] = 0.0d;
+			}
+		}
+		Spot circle = graph.addVertex().init( 0, center, cov );
+		renderSpot( circle, pixelValue, img );
+	}
+
+	public static void renderLine( final double[] center, final double length, final Axis axis, final int pixelValue,
+			final Img< FloatType > img,
+			final ModelGraph graph )
+	{
+		double[][] cov = new double[ 3 ][ 3 ];
+		double halfLengthSquared = ( length / 2 - ELLIPSOID_INFLATE ) * ( length / 2 - ELLIPSOID_INFLATE );
+		double minimalCov = 0.01d;
+		cov[ 0 ][ 0 ] = axis.equals( Axis.X ) ? halfLengthSquared : minimalCov;
+		cov[ 1 ][ 1 ] = axis.equals( Axis.Y ) ? halfLengthSquared : minimalCov;
+		cov[ 2 ][ 2 ] = axis.equals( Axis.Z ) ? halfLengthSquared : minimalCov;
+		Spot line = graph.addVertex().init( 0, center, cov );
+		renderSpot( line, pixelValue, img );
+	}
+
+	public enum Plane
+	{
+		XY,
+		XZ,
+		YZ
+	}
+
+	public enum Axis
+	{
+		X,
+		Y,
+		Z
+	}
+}


### PR DESCRIPTION
This PR introduces that during the import of label images as ellipsoids some edge case are handled properly.

1. Single Pixel case: Results now in a sphere with ~1pixel radius
2. Planar pixels (e.g. a line or a circle): Results now in ellipsoids with semi axes of at least 0.5pixel

Import result before PR (the upper row shows circles/line that are only in the x-y plane, the lower row shows spheres):
![grafik](https://github.com/mastodon-sc/mastodon-deep-lineage/assets/10515534/8ab751f6-804f-41d9-8c0a-70d3af75c74f)

Import result after PR (the upper row shows circles/line that are only in the x-y plane, the lower row shows spheres):
![grafik](https://github.com/mastodon-sc/mastodon-deep-lineage/assets/10515534/970a4f1f-bc96-4d47-8ff8-3d02673f5c03)
