### PR TITLE
Select resolution level in export ellipsoid to label image

### DIFF
--- a/src/main/java/org/mastodon/mamut/io/exporter/labelimage/ExportLabelImageController.java
+++ b/src/main/java/org/mastodon/mamut/io/exporter/labelimage/ExportLabelImageController.java
@@ -140,7 +140,7 @@ public class ExportLabelImageController
 		logger.info( "Save label image to file. Label options: {}, file: {}", labelOption, file.getAbsolutePath() );
 		long[] spatialDimensions = getDimensionsOfSource( mipMapLevel );
 		int numTimePoints = timePoints.size();
-		int frames = getResultingNumberOfFrames( numTimePoints, frameRateReduction );
+		int frames = divideAndRoundUp( numTimePoints, frameRateReduction );
 		logger.debug(
 				"number of timepoints: {}, frame rate reduction: {}, resulting frames: {}", numTimePoints, frameRateReduction, frames );
 		DiskCachedCellImg< FloatType, ? > img = createCachedImage( spatialDimensions, frames );
@@ -302,17 +302,12 @@ public class ExportLabelImageController
 	 *     <li>timepoints: 20, frame rate reduction: 10 ->  2 frames</li>
 	 * </ul>
 	 *
-	 * @param numTimePoints the number of timepoints
-	 * @param frameRateReduction the frame rate reduction
+	 * @param numerator the number of timepoints
+	 * @param denominator the frame rate reduction
 	 * @return the resulting number of frames
 	 */
-	static int getResultingNumberOfFrames( final int numTimePoints, final int frameRateReduction )
+	static int divideAndRoundUp( int numerator, int denominator )
 	{
-		int frames = numTimePoints / frameRateReduction;
-		if ( numTimePoints > frameRateReduction && numTimePoints % frameRateReduction != 0 && frameRateReduction > 1 )
-			frames++;
-		if ( frames == 0 )
-			frames = 1;
-		return frames;
+		return ( numerator + denominator - 1 ) / denominator;
 	}
 }

--- a/src/main/java/org/mastodon/mamut/io/exporter/labelimage/ExportLabelImageController.java
+++ b/src/main/java/org/mastodon/mamut/io/exporter/labelimage/ExportLabelImageController.java
@@ -163,7 +163,7 @@ public class ExportLabelImageController
 			processAllSpotsOfFrame( ellipsoidIterable, labelOption, sourceFrameId, targetFrameId, frames );
 		}
 		lock.unlock();
-		logger.debug( "Export finished." );
+		logger.debug( "Generating labels from ellipsoids finished." );
 
 		ImgPlus< FloatType > imgplus = createImgPlus( img );
 		saveImgPlus( file, imgplus );

--- a/src/main/java/org/mastodon/mamut/io/exporter/labelimage/ExportLabelImageController.java
+++ b/src/main/java/org/mastodon/mamut/io/exporter/labelimage/ExportLabelImageController.java
@@ -142,9 +142,7 @@ public class ExportLabelImageController
 		logger.info( "Save label image to file. Label options: {}, file: {}", labelOption, file.getAbsolutePath() );
 		long[] spatialDimensions = getDimensionsOfSource( mipMapLevel );
 		int numTimePoints = timePoints.size();
-		int frames = numTimePoints / frameRateReduction;
-		if ( numTimePoints > frameRateReduction && frameRateReduction > 1 )
-			frames++;
+		int frames = getResultingNumberOfFrames( numTimePoints, frameRateReduction );
 		logger.debug(
 				"number of timepoints: {}, frame rate reduction: {}, resulting frames: {}", numTimePoints, frameRateReduction, frames );
 		DiskCachedCellImg< IntType, ? > img = createCachedImage( spatialDimensions, frames );
@@ -292,5 +290,33 @@ public class ExportLabelImageController
 		final MamutFeatureComputerService featureComputerService = MamutFeatureComputerService.newInstance( context );
 		featureComputerService.setModel( model );
 		return featureComputerService;
+	}
+
+	/**
+	 * Calculate the number of frames to use for the export depending on the number of timepoints and the frame rate reduction.
+	 * <br>
+	 * Some examples:
+	 * <br>
+	 * <ul>
+	 *     <li>timepoints: 1,  frame rate reduction:  1 ->  1 frame</li>
+	 *     <li>timepoints: 1,  frame rate reduction: 10 ->  1 frame</li>
+	 *     <li>timepoints: 10, frame rate reduction: 10 ->  1 frame</li>
+	 *     <li>timepoints: 10, frame rate reduction:  1 -> 10 frames</li>
+	 *     <li>timepoints: 11, frame rate reduction: 10 ->  2 frames</li>
+	 *     <li>timepoints: 20, frame rate reduction: 10 ->  2 frames</li>
+	 * </ul>
+	 *
+	 * @param numTimePoints the number of timepoints
+	 * @param frameRateReduction the frame rate reduction
+	 * @return the resulting number of frames
+	 */
+	static int getResultingNumberOfFrames( final int numTimePoints, final int frameRateReduction )
+	{
+		int frames = numTimePoints / frameRateReduction;
+		if ( numTimePoints > frameRateReduction && numTimePoints % frameRateReduction != 0 && frameRateReduction > 1 )
+			frames++;
+		if ( frames == 0 )
+			frames = 1;
+		return frames;
 	}
 }

--- a/src/main/java/org/mastodon/mamut/io/exporter/labelimage/ExportLabelImageController.java
+++ b/src/main/java/org/mastodon/mamut/io/exporter/labelimage/ExportLabelImageController.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -31,10 +31,8 @@ package org.mastodon.mamut.io.exporter.labelimage;
 import bdv.util.AbstractSource;
 import bdv.util.RandomAccessibleIntervalSource;
 import bdv.viewer.Source;
+import ij.IJ;
 import ij.ImagePlus;
-import io.scif.codec.CompressionType;
-import io.scif.config.SCIFIOConfig;
-import io.scif.img.ImgSaver;
 import mpicbg.spim.data.sequence.TimePoint;
 import mpicbg.spim.data.sequence.VoxelDimensions;
 import net.imagej.ImgPlus;
@@ -269,11 +267,8 @@ public class ExportLabelImageController
 
 	private void saveImgPlus( File file, ImgPlus< IntType > imgplus )
 	{
-		SCIFIOConfig config = new SCIFIOConfig();
-		config.writerSetCompression( CompressionType.LZW );
-		config.writerSetFailIfOverwriting( false );
-		ImgSaver saver = new ImgSaver( context );
-		saver.saveImg( file.getAbsolutePath(), imgplus, config );
+		ImagePlus imagePlus = ImageJFunctions.wrap( imgplus, "Label image representing ellipsoids" );
+		IJ.saveAsTiff( imagePlus, file.getAbsolutePath() );
 	}
 
 	private static FeatureProjection< Spot > getTrackIDFeatureProjection( final Context context, final Model model )

--- a/src/main/java/org/mastodon/mamut/io/exporter/labelimage/ExportLabelImageController.java
+++ b/src/main/java/org/mastodon/mamut/io/exporter/labelimage/ExportLabelImageController.java
@@ -81,6 +81,8 @@ public class ExportLabelImageController
 
 	public static final int LABEL_ID_OFFSET = 1;
 
+	public static final int DEFAULT_SOURCE_ID = 0;
+
 	private static final Logger logger = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
 
 	private final Model model;
@@ -102,8 +104,9 @@ public class ExportLabelImageController
 		// NB: Use the dimensions of the first source and the first time point only without checking if they are equal in other sources and time points.
 		this( projectModel.getModel(),
 				projectModel.getSharedBdvData().getSpimData().getSequenceDescription().getTimePoints().getTimePointsOrdered(),
-				Cast.unchecked( projectModel.getSharedBdvData().getSources().get( 0 ).getSpimSource() ), context,
-				projectModel.getSharedBdvData().getSpimData().getSequenceDescription().getViewSetups().get( 0 ).getVoxelSize()
+				Cast.unchecked( projectModel.getSharedBdvData().getSources().get( DEFAULT_SOURCE_ID ).getSpimSource() ), context,
+				projectModel.getSharedBdvData().getSpimData().getSequenceDescription().getViewSetups().get( DEFAULT_SOURCE_ID )
+						.getVoxelSize()
 		);
 	}
 

--- a/src/main/java/org/mastodon/mamut/io/exporter/labelimage/ui/ExportLabelImageView.java
+++ b/src/main/java/org/mastodon/mamut/io/exporter/labelimage/ui/ExportLabelImageView.java
@@ -90,7 +90,8 @@ public class ExportLabelImageView extends DynamicCommand
 	@SuppressWarnings( "unused" )
 	private void initResolutionMinMax()
 	{
-		int mipMapLevels = projectModel.getSharedBdvData().getSources().get( 0 ).getSpimSource().getNumMipmapLevels();
+		int mipMapLevels = projectModel.getSharedBdvData().getSources().get( ExportLabelImageController.DEFAULT_SOURCE_ID ).getSpimSource()
+				.getNumMipmapLevels();
 		getInfo().getMutableInput( "resolutionLevel", Integer.class ).setMinimumValue( 0 );
 		getInfo().getMutableInput( "resolutionLevel", Integer.class ).setMaximumValue( mipMapLevels - 1 );
 	}

--- a/src/main/java/org/mastodon/mamut/io/exporter/labelimage/ui/ExportLabelImageView.java
+++ b/src/main/java/org/mastodon/mamut/io/exporter/labelimage/ui/ExportLabelImageView.java
@@ -51,7 +51,7 @@ public class ExportLabelImageView extends DynamicCommand
 			+ "<h1>Export label image using ellipsoids</h1>\n"
 			+ "<p>This plugin is capable of saving a label image to a file using the existing ellipsoids in Mastodon.</p>\n"
 			+ "<p>For the labels, the <i>spot ids</i>, <i>branch spot ids</i> or the <i>track ids</i> that correspond to the ellipsoids may be used. Since these Ids are counted zero based in Mastodon, an <b>offset of 1</b> is added to all Ids so that no label clashes with the background of zero.</p>\n"
-			+ "<p>The recommended export format is to '*.tif'-files. However, it should work also for other formats supported by ImageJ.</p>\n"
+			+ "<p>The supported export format is '*.tif'-files.</p>\n"
 			+ "</body>\n"
 			+ "</html>\n";
 

--- a/src/main/java/org/mastodon/mamut/io/exporter/labelimage/ui/ExportLabelImageView.java
+++ b/src/main/java/org/mastodon/mamut/io/exporter/labelimage/ui/ExportLabelImageView.java
@@ -60,7 +60,7 @@ public class ExportLabelImageView extends DynamicCommand
 	private String option = LabelOptions.BRANCH_SPOT_ID.getName();
 
 	@SuppressWarnings("all")
-	@Parameter(label = "Frame rate reduction", description = "Only export every n-th. 1 means no reduction. Value must be >= 1.", min = "1")
+	@Parameter( label = "Frame rate reduction", description = "Only export every n-th frame. 1 means no reduction. Value must be >= 1.", min = "1" )
 	private int frameRateReduction = 1;
 
 	@SuppressWarnings( "all" )

--- a/src/main/java/org/mastodon/mamut/io/exporter/labelimage/ui/ExportLabelImageView.java
+++ b/src/main/java/org/mastodon/mamut/io/exporter/labelimage/ui/ExportLabelImageView.java
@@ -51,7 +51,9 @@ public class ExportLabelImageView extends DynamicCommand
 			+ "<h1>Export label image using ellipsoids</h1>\n"
 			+ "<p>This plugin is capable of saving a label image to a file using the existing ellipsoids in Mastodon.</p>\n"
 			+ "<p>For the labels, the <i>spot ids</i>, <i>branch spot ids</i> or the <i>track ids</i> that correspond to the ellipsoids may be used. Since these Ids are counted zero based in Mastodon, an <b>offset of 1</b> is added to all Ids so that no label clashes with the background of zero.</p>\n"
+			+ "<p>Ids in the range between 0 and 16.777.216 (24 bit) are supported.</p>\n"
 			+ "<p>The supported export format is '*.tif'-files.</p>\n"
+			+ "<p>.</p>\n"
 			+ "</body>\n"
 			+ "</html>\n";
 

--- a/src/main/java/org/mastodon/mamut/io/exporter/labelimage/ui/ExportLabelImageView.java
+++ b/src/main/java/org/mastodon/mamut/io/exporter/labelimage/ui/ExportLabelImageView.java
@@ -63,6 +63,10 @@ public class ExportLabelImageView extends DynamicCommand
 	@Parameter(label = "Frame rate reduction", description = "Only export every n-th. 1 means no reduction. Value must be >= 1.", min = "1")
 	private int frameRateReduction = 1;
 
+	@SuppressWarnings( "all" )
+	@Parameter( label = "Resolution level", description = "Spatial resolution level of export. 0 means highest resolution. Value > 0 mean lower resolution.", initializer = "initResolutionMinMax" )
+	private int resolutionLevel = 0;
+
 	@SuppressWarnings("unused")
 	@Parameter(label = "Save to")
 	private File saveTo;
@@ -80,6 +84,14 @@ public class ExportLabelImageView extends DynamicCommand
 	{
 		ExportLabelImageController controller = new ExportLabelImageController( projectModel, getContext() );
 		LabelOptions selectedOption = LabelOptions.getByName( option );
-		controller.saveLabelImageToFile( selectedOption, saveTo, showResult, frameRateReduction );
+		controller.saveLabelImageToFile( selectedOption, saveTo, showResult, frameRateReduction, resolutionLevel );
+	}
+
+	@SuppressWarnings( "unused" )
+	private void initResolutionMinMax()
+	{
+		int mipMapLevels = projectModel.getSharedBdvData().getSources().get( 0 ).getSpimSource().getNumMipmapLevels();
+		getInfo().getMutableInput( "resolutionLevel", Integer.class ).setMinimumValue( 0 );
+		getInfo().getMutableInput( "resolutionLevel", Integer.class ).setMaximumValue( mipMapLevels - 1 );
 	}
 }

--- a/src/main/java/org/mastodon/mamut/io/exporter/labelimage/ui/ExportLabelImageView.java
+++ b/src/main/java/org/mastodon/mamut/io/exporter/labelimage/ui/ExportLabelImageView.java
@@ -31,16 +31,16 @@ package org.mastodon.mamut.io.exporter.labelimage.ui;
 import org.mastodon.mamut.ProjectModel;
 import org.mastodon.mamut.io.exporter.labelimage.ExportLabelImageController;
 import org.mastodon.mamut.io.exporter.labelimage.config.LabelOptions;
-import org.scijava.Context;
 import org.scijava.ItemVisibility;
 import org.scijava.command.Command;
+import org.scijava.command.DynamicCommand;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 import java.io.File;
 
 @Plugin(type = Command.class, label = "Run export label image using ellipsoids")
-public class ExportLabelImageView implements Command
+public class ExportLabelImageView extends DynamicCommand
 {
 	private static final int WIDTH = 15;
 
@@ -75,14 +75,10 @@ public class ExportLabelImageView implements Command
 	@Parameter
 	private ProjectModel projectModel;
 
-	@SuppressWarnings("unused")
-	@Parameter
-	private Context context;
-
 	@Override
 	public void run()
 	{
-		ExportLabelImageController controller = new ExportLabelImageController( projectModel, context );
+		ExportLabelImageController controller = new ExportLabelImageController( projectModel, getContext() );
 		LabelOptions selectedOption = LabelOptions.getByName( option );
 		controller.saveLabelImageToFile( selectedOption, saveTo, showResult, frameRateReduction );
 	}

--- a/src/test/java/org/mastodon/mamut/io/exporter/labelimage/ExportLabelImageControllerTest.java
+++ b/src/test/java/org/mastodon/mamut/io/exporter/labelimage/ExportLabelImageControllerTest.java
@@ -39,6 +39,7 @@ import net.imglib2.img.Img;
 import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.test.RandomImgs;
 import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.util.Cast;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -105,9 +106,9 @@ class ExportLabelImageControllerTest
 			exportLabelImageController.saveLabelImageToFile( LabelOptions.TRACK_ID, outputTrack, false, 1, 0 );
 
 			ImgOpener imgOpener = new ImgOpener( context );
-			SCIFIOImgPlus< IntType > imgSpot = getIntTypeSCIFIOImgPlus( imgOpener, outputSpot );
-			SCIFIOImgPlus< IntType > imgBranchSpot = getIntTypeSCIFIOImgPlus( imgOpener, outputBranchSpot );
-			SCIFIOImgPlus< IntType > imgTrack = getIntTypeSCIFIOImgPlus( imgOpener, outputTrack );
+			SCIFIOImgPlus< FloatType > imgSpot = getFloatTypeSCIFIOImgPlus( imgOpener, outputSpot );
+			SCIFIOImgPlus< FloatType > imgBranchSpot = getFloatTypeSCIFIOImgPlus( imgOpener, outputBranchSpot );
+			SCIFIOImgPlus< FloatType > imgTrack = getFloatTypeSCIFIOImgPlus( imgOpener, outputTrack );
 
 			// check that the spot id / branchSpot id / track id is used as value in the center of the spot
 			assertNotNull( imgSpot );
@@ -127,7 +128,7 @@ class ExportLabelImageControllerTest
 		}
 	}
 
-	private static SCIFIOImgPlus< IntType > getIntTypeSCIFIOImgPlus( ImgOpener imgOpener, File outputSpot )
+	private static SCIFIOImgPlus< FloatType > getFloatTypeSCIFIOImgPlus( ImgOpener imgOpener, File outputSpot )
 	{
 		List< SCIFIOImgPlus< ? > > imgsSpot = imgOpener.openImgs( outputSpot.getAbsolutePath() );
 		SCIFIOImgPlus< ? > imgSpot = imgsSpot.get( 0 );

--- a/src/test/java/org/mastodon/mamut/io/exporter/labelimage/ExportLabelImageControllerTest.java
+++ b/src/test/java/org/mastodon/mamut/io/exporter/labelimage/ExportLabelImageControllerTest.java
@@ -158,6 +158,17 @@ class ExportLabelImageControllerTest
 		}
 	}
 
+	@Test
+	void testGetResultingNumberOfFrames()
+	{
+		assertEquals( 1, ExportLabelImageController.getResultingNumberOfFrames( 1, 1 ) );
+		assertEquals( 1, ExportLabelImageController.getResultingNumberOfFrames( 1, 10 ) );
+		assertEquals( 1, ExportLabelImageController.getResultingNumberOfFrames( 10, 10 ) );
+		assertEquals( 10, ExportLabelImageController.getResultingNumberOfFrames( 10, 1 ) );
+		assertEquals( 2, ExportLabelImageController.getResultingNumberOfFrames( 11, 10 ) );
+		assertEquals( 2, ExportLabelImageController.getResultingNumberOfFrames( 20, 10 ) );
+	}
+
 	private static AbstractSource< IntType > createRandomSource()
 	{
 		Img< IntType > randomImg = RandomImgs.seed( 0 ).nextImage( new IntType()

--- a/src/test/java/org/mastodon/mamut/io/exporter/labelimage/ExportLabelImageControllerTest.java
+++ b/src/test/java/org/mastodon/mamut/io/exporter/labelimage/ExportLabelImageControllerTest.java
@@ -162,12 +162,12 @@ class ExportLabelImageControllerTest
 	@Test
 	void testGetResultingNumberOfFrames()
 	{
-		assertEquals( 1, ExportLabelImageController.getResultingNumberOfFrames( 1, 1 ) );
-		assertEquals( 1, ExportLabelImageController.getResultingNumberOfFrames( 1, 10 ) );
-		assertEquals( 1, ExportLabelImageController.getResultingNumberOfFrames( 10, 10 ) );
-		assertEquals( 10, ExportLabelImageController.getResultingNumberOfFrames( 10, 1 ) );
-		assertEquals( 2, ExportLabelImageController.getResultingNumberOfFrames( 11, 10 ) );
-		assertEquals( 2, ExportLabelImageController.getResultingNumberOfFrames( 20, 10 ) );
+		assertEquals( 1, ExportLabelImageController.divideAndRoundUp( 1, 1 ) );
+		assertEquals( 1, ExportLabelImageController.divideAndRoundUp( 1, 10 ) );
+		assertEquals( 1, ExportLabelImageController.divideAndRoundUp( 10, 10 ) );
+		assertEquals( 10, ExportLabelImageController.divideAndRoundUp( 10, 1 ) );
+		assertEquals( 2, ExportLabelImageController.divideAndRoundUp( 11, 10 ) );
+		assertEquals( 2, ExportLabelImageController.divideAndRoundUp( 20, 10 ) );
 	}
 
 	private static AbstractSource< IntType > createRandomSource()

--- a/src/test/java/org/mastodon/mamut/io/exporter/labelimage/ExportLabelImageControllerTest.java
+++ b/src/test/java/org/mastodon/mamut/io/exporter/labelimage/ExportLabelImageControllerTest.java
@@ -100,9 +100,9 @@ class ExportLabelImageControllerTest
 			File outputSpot = getTempFile( "resultSpot" );
 			File outputBranchSpot = getTempFile( "resultBranchSpot" );
 			File outputTrack = getTempFile( "resultTrack" );
-			exportLabelImageController.saveLabelImageToFile( LabelOptions.SPOT_ID, outputSpot, false, 1 );
-			exportLabelImageController.saveLabelImageToFile( LabelOptions.BRANCH_SPOT_ID, outputBranchSpot, false, 1 );
-			exportLabelImageController.saveLabelImageToFile( LabelOptions.TRACK_ID, outputTrack, false, 1 );
+			exportLabelImageController.saveLabelImageToFile( LabelOptions.SPOT_ID, outputSpot, false, 1, 0 );
+			exportLabelImageController.saveLabelImageToFile( LabelOptions.BRANCH_SPOT_ID, outputBranchSpot, false, 1, 0 );
+			exportLabelImageController.saveLabelImageToFile( LabelOptions.TRACK_ID, outputTrack, false, 1, 0 );
 
 			ImgOpener imgOpener = new ImgOpener( context );
 			SCIFIOImgPlus< IntType > imgSpot = getIntTypeSCIFIOImgPlus( imgOpener, outputSpot );
@@ -152,9 +152,9 @@ class ExportLabelImageControllerTest
 			file.deleteOnExit();
 			assertThrows(
 					IllegalArgumentException.class,
-					() -> controller.saveLabelImageToFile( LabelOptions.SPOT_ID, null, false, 1 )
+					() -> controller.saveLabelImageToFile( LabelOptions.SPOT_ID, null, false, 1, 0 )
 			);
-			assertThrows( IllegalArgumentException.class, () -> controller.saveLabelImageToFile( null, file, false, 1 ) );
+			assertThrows( IllegalArgumentException.class, () -> controller.saveLabelImageToFile( null, file, false, 1, 0 ) );
 		}
 	}
 

--- a/src/test/java/org/mastodon/mamut/io/exporter/labelimage/ui/ExportLabelImageViewDemo.java
+++ b/src/test/java/org/mastodon/mamut/io/exporter/labelimage/ui/ExportLabelImageViewDemo.java
@@ -28,6 +28,12 @@
  */
 package org.mastodon.mamut.io.exporter.labelimage.ui;
 
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.real.FloatType;
+import org.mastodon.mamut.ProjectModel;
+import org.mastodon.mamut.io.importer.labelimage.util.DemoUtils;
+import org.mastodon.mamut.model.Model;
 import org.scijava.Context;
 import org.scijava.command.CommandService;
 import org.scijava.ui.UIService;
@@ -43,6 +49,9 @@ public class ExportLabelImageViewDemo
 		CommandService cmd = context.service( CommandService.class );
 
 		ui.showUI();
-		cmd.run( ExportLabelImageView.class, true, "projectModel", null );
+		Model model = new Model();
+		Img< FloatType > img = ArrayImgs.floats( 1, 1, 1 );
+		ProjectModel projectModel = DemoUtils.wrapAsAppModel( img, model, context );
+		cmd.run( ExportLabelImageView.class, true, "projectModel", projectModel );
 	}
 }


### PR DESCRIPTION
So far, it is possible to reduce the temporal resolution, when export the ellipsoids of Mastodon as label image.

This PR introduces the possibility to reduce the spatial resolution, since this may be handy to reduce the export time and the size of the resulting image.

For this purpose, this PR introduces the possibility that the user can decide for a mip map level that exists in the first source of the image and export the ellipsoids to the label image at the resolution of this mip map level.

Moreover, the export using SCIFIO turned out to be slow for larger datasets. Using the ImageJ export helps to speed up this process.