### PR TITLE
Use com.opencsv for writing CSV file in the export of clustering results

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,12 +117,6 @@
             <artifactId>jfreesvg</artifactId>
         </dependency>
 
-        <!-- export of lineage classification results to csv -->
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-csv</artifactId>
-        </dependency>
-
         <!-- UMAP -->
         <dependency>
             <groupId>tech.molecules</groupId>
@@ -156,6 +150,13 @@
         <dependency>
             <groupId>nz.ac.waikato.cms.weka</groupId>
             <artifactId>weka-dev</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- testing export of lineage clustering results to csv -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/org/mastodon/mamut/clustering/util/HierarchicalClusteringResult.java
+++ b/src/main/java/org/mastodon/mamut/clustering/util/HierarchicalClusteringResult.java
@@ -29,8 +29,7 @@
 package org.mastodon.mamut.clustering.util;
 
 import com.apporiented.algorithm.clustering.Cluster;
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVPrinter;
+import com.opencsv.CSVWriter;
 import org.apache.commons.lang3.tuple.Pair;
 import org.mastodon.mamut.clustering.config.HasName;
 import org.mastodon.mamut.clustering.treesimilarity.tree.BranchSpotTree;
@@ -227,19 +226,12 @@ public class HierarchicalClusteringResult< T >
 	 */
 	public void exportCsv( final File file, final TagSetStructure.TagSet tagSet )
 	{
-		char separator = ';';
-		String[] header = new String[] { "Cell name", tagSet == null ? "" : tagSet.getName(), "Group", "Group similarity score" };
-		//CSVFormat csvFormat = CSVFormat.Builder.create().setHeader( header ).setDelimiter( separator ).setQuote( '"' ).setEscape( '"' )
-		//		.setRecordSeparator( "\n" ).build();
-		// TODO: the following code is deprecated. However, it needs to be used at the moment, because an old version
-		// of the commons-csv library on the tomancak update site is shadowing newer versions of the library uploaded
-		// the DeepLineage update site. This should be fixed after the tomancak update site has been updated.
-		CSVFormat csvFormat = CSVFormat.DEFAULT.withHeader( header ).withDelimiter( separator ).withQuote( '"' ).withEscape( '"' )
-				.withRecordSeparator( "\n" );
+		String[] header = new String[] { "Cell name", tagSet == null ? "" : tagSet.getName(), "Group", "Similarity score" };
 		try (
 				FileWriter writer = new FileWriter( file );
-				CSVPrinter csvPrinter = new CSVPrinter( writer, csvFormat ))
+				CSVWriter csvWriter = new CSVWriter( writer, ';', '"', '"', "\n" ))
 		{
+			csvWriter.writeNext( header );
 			for ( Group< T > group : getGroups() )
 			{
 				for ( T object : group.getObjects() )
@@ -249,13 +241,12 @@ public class HierarchicalClusteringResult< T >
 					String groupName = group.getName();
 					String similarity =
 							MathUtils.roundToSignificantDigits( group.getCluster().getDistance().getDistance(), 2 );
-					Object[] line = new String[] { name, tagLabel, groupName, similarity };
-					csvPrinter.printRecord( line );
+					csvWriter.writeNext( new String[] { name, tagLabel, groupName, similarity } );
 					logger.debug( "Cell name: {}, Tag label: {}, Group name: {}, Similarity of group: {}", name, tagLabel, groupName,
 							similarity );
 				}
 			}
-			csvPrinter.flush();
+			csvWriter.flush();
 		}
 		catch ( IOException e )
 		{

--- a/src/test/java/org/mastodon/mamut/clustering/util/HierarchicalClusteringResultTest.java
+++ b/src/test/java/org/mastodon/mamut/clustering/util/HierarchicalClusteringResultTest.java
@@ -79,8 +79,7 @@ class HierarchicalClusteringResultTest
 		tempFileCsv.deleteOnExit();
 
 		hierarchicalClusteringResult.exportCsv( tempFileCsv, null );
-		CSVFormat csvFormat = CSVFormat.Builder.create().setDelimiter( ";" ).setQuote( '"' ).setEscape( '"' )
-				.setRecordSeparator( "\n" ).build();
+		CSVFormat csvFormat = CSVFormat.Builder.create().setDelimiter( ";" ).setQuote( '"' ).setRecordSeparator( "\n" ).build();
 		try (
 				Reader reader = new FileReader( tempFileCsv );
 				CSVParser csvParser = new CSVParser( reader, csvFormat )


### PR DESCRIPTION
This PR streamlines the use of CSV libraries with Mastodon core

* com.opencsv is part of Fiji core and used in Mastodon core. Thus no need to add another CSV library such as commons-csv
* commons-csv is still used for the unit test, since in com.opencsv the reader cannot be customized