### PR TITLE
Allow Umap with 1 target dimension

### DIFF
--- a/src/main/java/org/mastodon/mamut/feature/branch/dimensionalityreduction/umap/BranchUmapFeature.java
+++ b/src/main/java/org/mastodon/mamut/feature/branch/dimensionalityreduction/umap/BranchUmapFeature.java
@@ -49,7 +49,7 @@ import java.util.List;
  */
 public class BranchUmapFeature extends AbstractUmapFeature< BranchSpot >
 {
-	public static final String KEY = "Branch Umap outputs";
+	public static final String KEY = "Branch Umap output";
 
 	private final BranchSpotUmapFeatureSpec adaptedSpec;
 

--- a/src/main/java/org/mastodon/mamut/feature/dimensionalityreduction/ui/DimensionalityReductionView.java
+++ b/src/main/java/org/mastodon/mamut/feature/dimensionalityreduction/ui/DimensionalityReductionView.java
@@ -117,6 +117,8 @@ public class DimensionalityReductionView extends JFrame
 
 	private static final String PANEL_CONSTRAINTS = "span, growx, pushx, growy, pushy, wrap";
 
+	private static final int MINIMUM_NUMBER_OF_DIMENSIONS = 1;
+
 	public DimensionalityReductionView( final Model model, final Context context )
 	{
 		this.featureModel = model.getFeatureModel();
@@ -320,7 +322,7 @@ public class DimensionalityReductionView extends JFrame
 	{
 		int maximumNumberOfDimensions = Math.max( 2, inputDimensionsPanel.getNumberOfFeatures() );
 		int numberOfDimensions = Math.min( controller.getCommonSettings().getNumberOfOutputDimensions(), maximumNumberOfDimensions );
-		return new SpinnerNumberModel( numberOfDimensions, CommonSettings.DEFAULT_NUMBER_OF_OUTPUT_DIMENSIONS,
+		return new SpinnerNumberModel( numberOfDimensions, MINIMUM_NUMBER_OF_DIMENSIONS,
 				maximumNumberOfDimensions, 1 );
 	}
 

--- a/src/main/java/org/mastodon/mamut/feature/spot/dimensionalityreduction/umap/SpotUmapFeature.java
+++ b/src/main/java/org/mastodon/mamut/feature/spot/dimensionalityreduction/umap/SpotUmapFeature.java
@@ -49,7 +49,7 @@ import java.util.List;
  */
 public class SpotUmapFeature extends AbstractUmapFeature< Spot >
 {
-	public static final String KEY = "Spot Umap outputs";
+	public static final String KEY = "Spot Umap output";
 
 	private final SpotUmapFeatureSpec adaptedSpec;
 


### PR DESCRIPTION
This PR will allow the user to reduce the dimension using UMAP also to just 1 dimension. Before the minimum number of dimensions to reduce to was 2.