### PR TITLE
Update pom to beta 35 and scijava 42

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.scijava</groupId>
         <artifactId>pom-scijava</artifactId>
-        <version>40.0.0</version>
+        <version>42.0.0</version>
     </parent>
 
     <groupId>org.mastodon</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <license.organizationName>Mastodon authors</license.organizationName>
         <license.copyrightOwners>Stefan Hahmann</license.copyrightOwners>
 
-        <mastodon.version>1.0.0-beta-34</mastodon.version>
+        <mastodon.version>1.0.0-beta-35</mastodon.version>
         <mastodon-tracking.version>1.0.0-beta-20</mastodon-tracking.version>
         <mastodon.group>org.mastodon</mastodon.group>
         <!-- when a pom-scijava exists that references the scijava-common 2.99.1 release, this can be removed again -->


### PR DESCRIPTION
This pull request updates project dependencies in the `pom.xml` file to use newer versions, ensuring compatibility and access to the latest features and fixes.

Dependency version updates:

* Upgraded the parent `pom-scijava` version from `40.0.0` to `42.0.0` to align with the latest SciJava standards and improvements.
* Updated the `mastodon.version` property from `1.0.0-beta-34` to `1.0.0-beta-35` for the core Mastodon library, bringing in the latest bug fixes and enhancements.